### PR TITLE
fix: WebSocketサイレント切断を検知して自動再接続する

### DIFF
--- a/cmd/gogocoin/bootstrap.go
+++ b/cmd/gogocoin/bootstrap.go
@@ -189,6 +189,7 @@ func Run(ctx context.Context, cfg *config.Config, log logger.LoggerInterface) er
 		cfg.Worker.ReconnectIntervalSeconds,
 		cfg.Worker.MaxReconnectIntervalSeconds,
 		cfg.Worker.ConnectionCheckIntervalSeconds,
+		cfg.Worker.StaleDataTimeoutSeconds,
 	)
 	strategyWorker := adapterworker.NewStrategyWorker(log, strat, marketDataCh, signalCh)
 	signalWorker := adapterworker.NewSignalWorker(log, signalCh, tradingCtrl, riskMgr, trader, strat, perfAnalytics, cfg.Runtime.SellSizePercentage)

--- a/internal/adapter/worker/market_data.go
+++ b/internal/adapter/worker/market_data.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/bmf-san/gogocoin/v1/internal/domain"
@@ -14,6 +15,7 @@ const (
 	defaultReconnectInterval       = 10 * time.Second
 	defaultMaxReconnectInterval    = 5 * time.Minute
 	defaultConnectionCheckInterval = 30 * time.Second
+	defaultStaleDataTimeout        = 3 * time.Minute
 )
 
 // MarketDataWorker manages WebSocket connections and market data subscriptions
@@ -25,6 +27,8 @@ type MarketDataWorker struct {
 	reconnectInterval       time.Duration
 	maxReconnectInterval    time.Duration
 	connectionCheckInterval time.Duration
+	staleDataTimeout        time.Duration
+	lastDataReceivedNs      atomic.Int64 // unix nanoseconds; updated on every ticker callback
 }
 
 // ClientFactory defines the interface for creating and managing clients
@@ -43,6 +47,7 @@ func NewMarketDataWorker(
 	reconnectIntervalSec int,
 	maxReconnectIntervalSec int,
 	connectionCheckIntervalSec int,
+	staleDataTimeoutSec int,
 ) *MarketDataWorker {
 	// Clamp to defaults to prevent zero/negative duration panics in time.NewTicker
 	if reconnectIntervalSec <= 0 {
@@ -54,6 +59,9 @@ func NewMarketDataWorker(
 	if connectionCheckIntervalSec <= 0 {
 		connectionCheckIntervalSec = int(defaultConnectionCheckInterval.Seconds())
 	}
+	if staleDataTimeoutSec <= 0 {
+		staleDataTimeoutSec = int(defaultStaleDataTimeout.Seconds())
+	}
 	return &MarketDataWorker{
 		logger:                  logger,
 		symbols:                 symbols,
@@ -62,6 +70,7 @@ func NewMarketDataWorker(
 		reconnectInterval:       time.Duration(reconnectIntervalSec) * time.Second,
 		maxReconnectInterval:    time.Duration(maxReconnectIntervalSec) * time.Second,
 		connectionCheckInterval: time.Duration(connectionCheckIntervalSec) * time.Second,
+		staleDataTimeout:        time.Duration(staleDataTimeoutSec) * time.Second,
 	}
 }
 
@@ -126,6 +135,7 @@ func (w *MarketDataWorker) Run(ctx context.Context) error {
 
 			err := w.clientFactory.SubscribeToTicker(ctx, symbol, func(data domain.MarketData) {
 				w.logger.Data().WithField("symbol", data.Symbol).WithField("close", data.Close).Debug("Market data received in callback")
+				w.lastDataReceivedNs.Store(time.Now().UnixNano())
 
 				select {
 				case w.marketDataCh <- data:
@@ -161,6 +171,9 @@ func (w *MarketDataWorker) Run(ctx context.Context) error {
 			w.logger.Data().WithField("subscribed_symbols", subscribedCount).WithField("total_symbols", len(w.symbols)).Info("Market data subscriptions completed")
 		}
 
+		// Reset last-data timestamp so the stale-data detector doesn't trip immediately
+		w.lastDataReceivedNs.Store(time.Now().UnixNano())
+
 		// Monitor connection health
 		ticker := time.NewTicker(w.connectionCheckInterval)
 
@@ -172,6 +185,18 @@ func (w *MarketDataWorker) Run(ctx context.Context) error {
 					w.logger.Data().Warn("WebSocket connection lost, initiating reconnection")
 					ticker.Stop()
 					break monitorLoop // Exit inner loop to reconnect
+				}
+				// Stale data check: reconnect if no ticker has arrived for staleDataTimeout
+				if elapsed := time.Since(time.Unix(0, w.lastDataReceivedNs.Load())); elapsed > w.staleDataTimeout {
+					w.logger.Data().
+						WithField("elapsed_seconds", elapsed.Seconds()).
+						Warn("No market data received - WebSocket may be silently dead, forcing reconnection")
+					ticker.Stop()
+					// Mark disconnected so the outer loop will call ReconnectClient
+					if rc, ok := w.clientFactory.(interface{ SetDisconnected() }); ok {
+						rc.SetDisconnected()
+					}
+					break monitorLoop
 				}
 			case <-ctx.Done():
 				ticker.Stop()

--- a/internal/adapter/worker/market_data_test.go
+++ b/internal/adapter/worker/market_data_test.go
@@ -28,14 +28,14 @@ func createTestLogger(t *testing.T) *logger.Logger {
 
 // mockClientFactory implements ClientFactory for testing
 type mockClientFactory struct {
-	mu                  sync.Mutex
-	connected           bool
-	reconnectError      error
-	reconnectCallCount  int
-	subscribeError      error
-	subscribeCallCount  int
-	simulateDisconnect  bool
-	disconnectAfter     int // Disconnect after N subscription calls
+	mu                 sync.Mutex
+	connected          bool
+	reconnectError     error
+	reconnectCallCount int
+	subscribeError     error
+	subscribeCallCount int
+	simulateDisconnect bool
+	disconnectAfter    int // Disconnect after N subscription calls
 }
 
 func (m *mockClientFactory) IsConnected() bool {
@@ -129,6 +129,7 @@ func TestMarketDataWorker_ReconnectionScenario(t *testing.T) {
 			1,   // 1 second reconnect interval
 			300, // 5 minutes max
 			1,   // 1 second connection check
+			0,   // stale data timeout (default 3m)
 		)
 
 		// Start worker in background
@@ -188,6 +189,7 @@ func TestMarketDataWorker_ReconnectionScenario(t *testing.T) {
 			1,   // 1 second reconnect interval
 			300, // 5 minutes max
 			1,   // 1 second connection check
+			0,   // stale data timeout (default 3m)
 		)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -236,6 +238,7 @@ func TestMarketDataWorker_ReconnectionScenario(t *testing.T) {
 			1,   // 1 second reconnect interval
 			300, // 5 minutes max
 			1,   // 1 second connection check
+			0,   // stale data timeout (default 3m)
 		)
 
 		// Start worker
@@ -284,6 +287,7 @@ func TestMarketDataWorker_ReconnectionScenario(t *testing.T) {
 			1,
 			300,
 			1,
+			0,
 		)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -325,6 +329,7 @@ func TestMarketDataWorker_ChannelManagement(t *testing.T) {
 			1,
 			300,
 			1,
+			0,
 		)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -375,6 +380,7 @@ func TestMarketDataWorker_ChannelManagement(t *testing.T) {
 			1,
 			300,
 			1,
+			0,
 		)
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,6 +224,9 @@ func (c *Config) Validate() error {
 		if c.Worker.ConnectionCheckIntervalSeconds == 0 {
 			c.Worker.ConnectionCheckIntervalSeconds = defaults.ConnectionCheckIntervalSeconds
 		}
+		if c.Worker.StaleDataTimeoutSeconds == 0 {
+			c.Worker.StaleDataTimeoutSeconds = defaults.StaleDataTimeoutSeconds
+		}
 		if c.Worker.MaxConcurrentSaves == 0 {
 			c.Worker.MaxConcurrentSaves = defaults.MaxConcurrentSaves
 		}

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -9,9 +9,10 @@ type WorkerConfig struct {
 	SignalChannelBuffer     int `yaml:"signal_channel_buffer"`
 
 	// Reconnection settings
-	ReconnectIntervalSeconds        int `yaml:"reconnect_interval_seconds"`
-	MaxReconnectIntervalSeconds     int `yaml:"max_reconnect_interval_seconds"`
-	ConnectionCheckIntervalSeconds  int `yaml:"connection_check_interval_seconds"`
+	ReconnectIntervalSeconds       int `yaml:"reconnect_interval_seconds"`
+	MaxReconnectIntervalSeconds    int `yaml:"max_reconnect_interval_seconds"`
+	ConnectionCheckIntervalSeconds int `yaml:"connection_check_interval_seconds"`
+	StaleDataTimeoutSeconds        int `yaml:"stale_data_timeout_seconds"`
 
 	// Database save settings
 	MaxConcurrentSaves int `yaml:"max_concurrent_saves"`
@@ -32,9 +33,9 @@ type WorkerConfig struct {
 // MarketDataWorkerConfig represents market data worker configuration
 type MarketDataWorkerConfig struct {
 	// Reconnection settings
-	ReconnectInterval        time.Duration `yaml:"reconnect_interval"`
-	MaxReconnectInterval     time.Duration `yaml:"max_reconnect_interval"`
-	ConnectionCheckInterval  time.Duration `yaml:"connection_check_interval"`
+	ReconnectInterval       time.Duration `yaml:"reconnect_interval"`
+	MaxReconnectInterval    time.Duration `yaml:"max_reconnect_interval"`
+	ConnectionCheckInterval time.Duration `yaml:"connection_check_interval"`
 }
 
 // SignalWorkerConfig represents signal worker configuration
@@ -68,11 +69,12 @@ type MaintenanceWorkerConfig struct {
 func DefaultWorkerConfig() WorkerConfig {
 	return WorkerConfig{
 		MarketDataChannelBuffer:        1000,
-		SignalChannelBuffer:             100,
-		ReconnectIntervalSeconds:        10,
-		MaxReconnectIntervalSeconds:     300,
-		ConnectionCheckIntervalSeconds:  30,
-		MaxConcurrentSaves:              10,
+		SignalChannelBuffer:            100,
+		ReconnectIntervalSeconds:       10,
+		MaxReconnectIntervalSeconds:    300,
+		ConnectionCheckIntervalSeconds: 30,
+		StaleDataTimeoutSeconds:        180,
+		MaxConcurrentSaves:             10,
 		MarketData: MarketDataWorkerConfig{
 			ReconnectInterval:       10 * time.Second,
 			MaxReconnectInterval:    5 * time.Minute,

--- a/internal/infra/exchange/bitflyer/client.go
+++ b/internal/infra/exchange/bitflyer/client.go
@@ -145,6 +145,14 @@ func (c *Client) IsConnected() bool {
 	return c.isConnected
 }
 
+// SetDisconnected marks the client as disconnected so the worker will reconnect.
+// Used by the market data worker when it detects a silently dead WebSocket.
+func (c *Client) SetDisconnected() {
+	c.mu.Lock()
+	c.isConnected = false
+	c.mu.Unlock()
+}
+
 // Close closes the client
 func (c *Client) Close(ctx context.Context) error {
 	c.mu.Lock()


### PR DESCRIPTION
## 概要

`IsConnected()` フラグは初期化時に `true` がセットされたまま実際の WebSocket 接続状態と乖離するため、一定時間データが届かない場合に自動で再接続する仕組みを追加する。

## 問題

- ticker の受信が完全に停止していることが判明
- プロセス自体は生存しているが WebSocket がサイレントに切断されたまま reconnect ロジックが発火しなかった
- 原因：`IsConnected()` が内部フラグを返すだけで実際の WS 状態を反映しないため、`monitorLoop` が切断を検知できなかった

## 変更内容

| ファイル | 変更 |
|---|---|
| `internal/adapter/worker/market_data.go` | `lastDataReceivedNs`（atomic）でコールバック毎に受信時刻を記録。`monitorLoop` で `staleDataTimeout` を超えたら強制再接続 |
| `internal/infra/exchange/bitflyer/client.go` | `SetDisconnected()` メソッドを追加 |
| `internal/config/worker.go` | `stale_data_timeout_seconds` フィールドを追加（デフォルト 180s） |
| `internal/config/config.go` | デフォルト値の適用処理を追加 |
| `cmd/gogocoin/bootstrap.go` | `NewMarketDataWorker` に新パラメータを渡す |

## 動作

1. ticker コールバックが呼ばれるたびに `lastDataReceivedNs` を現在時刻で更新
2. `connectionCheckInterval`（デフォルト 30s）ごとに「最後のデータ受信から `staleDataTimeout`（デフォルト 180s）以上経過していないか」をチェック
3. タイムアウトを超えた場合、`SetDisconnected()` で接続フラグを落とし、既存の reconnect ループを起動

## 備考

- `config.yaml` の取引パラメータ調整（EMA・利確・損切り）は git 管理外のため別途 `make config` でデプロイする