### PR TITLE
feat: add XLM_JPY and MONA_JPY market specs

### DIFF
--- a/internal/infra/exchange/bitflyer/market_specs.go
+++ b/internal/infra/exchange/bitflyer/market_specs.go
@@ -160,6 +160,20 @@ func (s *MarketSpecificationService) getHardcodedSpec(productCode string) *Marke
 			PriceMin:    0.0,
 			PriceMax:    1000.0,
 		},
+		"XLM_JPY": {
+			ProductCode: "XLM_JPY",
+			SizeMin:     10.0,
+			SizeMax:     10000000.0,
+			PriceMin:    0.0,
+			PriceMax:    100.0,
+		},
+		"MONA_JPY": {
+			ProductCode: "MONA_JPY",
+			SizeMin:     1.0,
+			SizeMax:     1000000.0,
+			PriceMin:    0.0,
+			PriceMax:    10000.0,
+		},
 		"BTC_USD": {
 			ProductCode: "BTC_USD",
 			SizeMin:     0.001,
@@ -182,7 +196,7 @@ func (s *MarketSpecificationService) getHardcodedSpec(productCode string) *Marke
 // populateFallbackSpecs populates cache with fallback specifications
 // when API is unavailable
 func (s *MarketSpecificationService) populateFallbackSpecs() {
-	fallbackSymbols := []string{"BTC_JPY", "ETH_JPY", "XRP_JPY", "BTC_USD", "BTC_EUR"}
+	fallbackSymbols := []string{"BTC_JPY", "ETH_JPY", "XRP_JPY", "XLM_JPY", "MONA_JPY", "BTC_USD", "BTC_EUR"}
 	for _, symbol := range fallbackSymbols {
 		if spec := s.getHardcodedSpec(symbol); spec != nil {
 			spec.FetchedAt = time.Now()

--- a/internal/usecase/strategy/scalping.go
+++ b/internal/usecase/strategy/scalping.go
@@ -298,6 +298,8 @@ func getMinimumOrderSizeFallback(symbol string) float64 {
 		return 10.0 // 10 XLM
 	case "MONA_JPY":
 		return 1.0 // 1 MONA
+	case "ELF_JPY":
+		return 1.0 // 1 ELF
 	case "BCH_JPY":
 		return 0.01 // 0.01 BCH
 	default:


### PR DESCRIPTION
## 概要

bitFlyer で取引可能なシンボル `XLM_JPY` と `MONA_JPY` の市場仕様をハードコードマップに追加しました。

## 変更内容

- `market_specs.go`: `getHardcodedSpec` に `XLM_JPY`（SizeMin: 10）と `MONA_JPY`（SizeMin: 1）を追加。`populateFallbackSpecs` にも両シンボルを追加
- `scalping.go`: `ELF_JPY` のフォールバック最小注文サイズを追加（bitFlyer現物シンボルで唯一 switch から漏れていたもの）

## シンボル取引可能性（2026-03-16時点）

| シンボル | 価格 | 最小ロット | 最小発注金額 |
|---|---|---|---|
| XRP_JPY | ~231 JPY | 1 XRP | ~231 JPY ✅ |
| XLM_JPY | ~27 JPY | 10 XLM | ~270 JPY ✅ |
| MONA_JPY | ~10.5 JPY | 1 MONA | ~10 JPY（出来高低め） |
| ETH_JPY | ~346,500 JPY | 0.01 ETH | ~3,465 JPY（より多い資金が必要） |