### PR TITLE
fix: deduplicate performance_metrics rows (INSERT OR REPLACE + unique date index)

### DIFF
--- a/internal/infra/persistence/performance_repo.go
+++ b/internal/infra/persistence/performance_repo.go
@@ -17,12 +17,14 @@ func NewPerformanceRepository(db *DB) *PerformanceRepository {
 // Compile-time check.
 var _ domain.PerformanceRepository = (*PerformanceRepository)(nil)
 
-// SavePerformanceMetric inserts a performance metric record.
+// SavePerformanceMetric upserts a performance metric record (one row per calendar day).
+// INSERT OR REPLACE relies on the unique index idx_perf_date_day on date(date)
+// added by migration 004_performance_upsert.sql.
 func (r *PerformanceRepository) SavePerformanceMetric(metric *domain.PerformanceMetric) error {
 	if metric.Date.IsZero() {
 		metric.Date = time.Now()
 	}
-	query := `INSERT INTO performance_metrics (date, total_return, daily_return, win_rate,
+	query := `INSERT OR REPLACE INTO performance_metrics (date, total_return, daily_return, win_rate,
 			  max_drawdown, sharpe_ratio, profit_factor, total_trades, winning_trades,
 			  losing_trades, average_win, average_loss, largest_win, largest_loss,
 			  consecutive_wins, consecutive_loss, total_pnl)

--- a/internal/infra/persistence/schema/004_performance_upsert.sql
+++ b/internal/infra/persistence/schema/004_performance_upsert.sql
@@ -1,0 +1,11 @@
+-- Deduplicate performance_metrics: keep only the most recent row per calendar day.
+-- This fixes the bug where UpdateMetrics (called after every trade) inserted a new row
+-- each time, resulting in hundreds of rows per day instead of one daily summary.
+DELETE FROM performance_metrics
+WHERE id NOT IN (
+    SELECT max(id) FROM performance_metrics GROUP BY date(date)
+);
+
+-- Add unique index on the date portion so future INSERTs are upserts (one row per day).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_perf_date_day
+    ON performance_metrics (date(date));


### PR DESCRIPTION
## Problem

`UpdateMetrics()` is called after every signal and was inserting a new row into `performance_metrics` each time via `INSERT INTO`. With hundreds of trades per day, hundreds of rows were generated for the same calendar day, causing the daily P&L table to show duplicates.

**Observed data (2026-03-18, 439 trades):**
```
2026/03/18  ¥84.65  38.60%  439
2026/03/18  ¥83.31  38.32%  437
2026/03/18  ¥83.31  38.32%  437
2026/03/18  ¥80.63  38.03%  436
...
```

## Changes

### `004_performance_upsert.sql` (new migration)
1. Delete existing duplicate rows (keep only the row with the highest `id` per calendar day)
2. Add a UNIQUE index on `date(date)`

```sql
DELETE FROM performance_metrics
WHERE id NOT IN (
    SELECT max(id) FROM performance_metrics GROUP BY date(date)
);

CREATE UNIQUE INDEX IF NOT EXISTS idx_perf_date_day
    ON performance_metrics (date(date));
```

### `performance_repo.go`
Change `INSERT INTO` → `INSERT OR REPLACE INTO`.

With the UNIQUE constraint from `idx_perf_date_day`, rows with the same calendar date are now upserted instead of duplicated.

## Result

- `performance_metrics` table holds exactly **one row per calendar day**
- Each trade updates the current day's row with the latest values
- No more duplicate rows in the daily P&L table
