### PR TITLE
feat: redesign dashboard UI with sleyt admin-dashboard layout

### DIFF
--- a/internal/infra/persistence/performance_repo.go
+++ b/internal/infra/persistence/performance_repo.go
@@ -17,12 +17,14 @@ func NewPerformanceRepository(db *DB) *PerformanceRepository {
 // Compile-time check.
 var _ domain.PerformanceRepository = (*PerformanceRepository)(nil)
 
-// SavePerformanceMetric inserts a performance metric record.
+// SavePerformanceMetric upserts a performance metric record (one row per calendar day).
+// INSERT OR REPLACE relies on the unique index idx_perf_date_day on date(date)
+// added by migration 004_performance_upsert.sql.
 func (r *PerformanceRepository) SavePerformanceMetric(metric *domain.PerformanceMetric) error {
 	if metric.Date.IsZero() {
 		metric.Date = time.Now()
 	}
-	query := `INSERT INTO performance_metrics (date, total_return, daily_return, win_rate,
+	query := `INSERT OR REPLACE INTO performance_metrics (date, total_return, daily_return, win_rate,
 			  max_drawdown, sharpe_ratio, profit_factor, total_trades, winning_trades,
 			  losing_trades, average_win, average_loss, largest_win, largest_loss,
 			  consecutive_wins, consecutive_loss, total_pnl)

--- a/internal/infra/persistence/schema/004_performance_upsert.sql
+++ b/internal/infra/persistence/schema/004_performance_upsert.sql
@@ -1,0 +1,11 @@
+-- Deduplicate performance_metrics: keep only the most recent row per calendar day.
+-- This fixes the bug where UpdateMetrics (called after every trade) inserted a new row
+-- each time, resulting in hundreds of rows per day instead of one daily summary.
+DELETE FROM performance_metrics
+WHERE id NOT IN (
+    SELECT max(id) FROM performance_metrics GROUP BY date(date)
+);
+
+-- Add unique index on the date portion so future INSERTs are upserts (one row per day).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_perf_date_day
+    ON performance_metrics (date(date));

--- a/web/index.html
+++ b/web/index.html
@@ -5,212 +5,314 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
     <title>gogocoin - トレーディングダッシュボード</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sleyt@1.2.0/dist/css/index.css" integrity="sha384-XAant6PZx4mPJlVxom7T5kv9aomwGExox10yMOslz7M3og33vxmFc3py2QhYbyHi" crossorigin="anonymous" />
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-      }
-    </style>
+    <link rel="stylesheet" href="https://unpkg.com/sleyt@latest/dist/css/index.css" />
   </head>
 
   <body class="bg-body">
-    <!-- Header -->
-    <header class="bg-slate-900 text-slate-50 py-4 px-4 shadow-xl">
-      <div class="flex justify-between items-center">
-        <div class="flex items-center gap-3">
-          <h1 class="text-3xl font-black m-0 tracking-tight">gogocoin</h1>
-        </div>
-        <div class="flex items-center gap-3">
-          <button id="start-trading-btn" class="btn btn-success btn-sm transition-transform duration-200 hover:scale-110 shadow-md">開始</button>
-          <button id="stop-trading-btn" class="btn btn-danger btn-sm transition-transform duration-200 hover:scale-110 shadow-md hidden">停止</button>
-        </div>
-      </div>
-    </header>
+    <input type="checkbox" id="sidebar-toggle" class="sidebar-toggle-checkbox" />
 
-    <!-- Main Content -->
-    <main class="container mx-auto p-8 pb-16">
-      <!-- Section 1: System, Market, Performance -->
-      <div class="grid grid-cols-1 md:grid-cols-2 mb-8">
-        <!-- System Status -->
-        <div class="card glass transition-all duration-300 hover:shadow-xl h-96 max-h-96 flex flex-col overflow-hidden">
-          <div class="card-header border-b border-slate-200">
-            <h2 class="font-bold text-lg">システム状態</h2>
+    <div class="dashboard">
+      <!-- ── Sidebar ── -->
+      <aside class="sidebar">
+        <a href="#" class="sidebar-brand">
+          <span class="sidebar-brand-icon">G</span>
+          gogocoin
+        </a>
+
+        <nav class="sidebar-nav">
+          <span class="sidebar-section-label">メイン</span>
+          <a href="#" class="sidebar-link active">
+            <svg class="sidebar-link-icon" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M10 2L2 9h2v9h4v-5h4v5h4V9h2L10 2z" />
+            </svg>
+            ダッシュボード
+          </a>
+          <a href="#" class="sidebar-link">
+            <svg class="sidebar-link-icon" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M2 17V9h4v8H2zM8 17V5h4v12H8zM14 17v-6h4v6h-4z" />
+            </svg>
+            パフォーマンス
+          </a>
+          <a href="#" class="sidebar-link">
+            <svg class="sidebar-link-icon" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M5 3h10v2H5zM3 7h14v2H3zM1 11h18v8H1z" />
+            </svg>
+            取引履歴
+          </a>
+          <a href="#" class="sidebar-link">
+            <svg class="sidebar-link-icon" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M10 2a8 8 0 100 16A8 8 0 0010 2zM9 5h2v2H9zM9 8h2v6H9z" />
+            </svg>
+            システムログ
+          </a>
+        </nav>
+
+        <div class="sidebar-footer">
+          <div id="trading-status-badge" class="sidebar-user">
+            <div class="sidebar-user-avatar">
+              <svg viewBox="0 0 20 20" fill="currentColor" style="width:1rem;height:1rem;">
+                <path d="M10 2L2 9h2v9h4v-5h4v5h4V9h2L10 2z" />
+              </svg>
+            </div>
+            <div class="min-w-0">
+              <p class="text-xs text-secondary leading-tight">取引状態</p>
+              <p class="text-sm font-semibold leading-tight">停止中</p>
+            </div>
           </div>
-          <div class="card-body flex-1 min-h-0 overflow-y-auto">
-            <div class="space-y-4">
-              <!-- Trading Status Badge -->
-              <div id="trading-status-badge" class="p-3 glass rounded-lg text-center border-2 border-slate-300 mb-3">
-                <p class="text-xs uppercase tracking-wide mb-1">取引状態</p>
-                <p class="text-lg font-black">停止中</p>
-              </div>
+        </div>
+      </aside>
 
-              <!-- Market Monitoring -->
-              <div class="p-3 bg-slate-50 rounded-lg border border-slate-200 mb-3">
-                <p class="text-xs text-secondary mb-2 uppercase tracking-wide">監視中の通貨ペア</p>
-                <div id="monitoring-prices" class="space-y-2">
-                  <div class="text-center text-secondary py-2 text-xs">読み込み中...</div>
+      <!-- ── Main Area ── -->
+      <div class="dashboard-main">
+        <!-- Topbar -->
+        <header class="topbar">
+          <label for="sidebar-toggle" class="sidebar-toggle-label" aria-label="Toggle sidebar">☰</label>
+          <div class="topbar-search">
+            <svg class="icon-sm" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M2 17V7l8-5 8 5v10h-5v-6H7v6z" />
+            </svg>
+            gogocoin トレーディングダッシュボード
+          </div>
+          <div class="flex items-center gap-2">
+            <button id="start-trading-btn" class="btn btn-success btn-sm">開始</button>
+            <button id="stop-trading-btn" class="btn btn-danger btn-sm hidden">停止</button>
+          </div>
+        </header>
+
+        <!-- Content -->
+        <div class="dashboard-content">
+          <!-- Page Header -->
+          <div class="mb-6">
+            <div class="flex items-center justify-between">
+              <h1 class="text-2xl font-bold">Overview</h1>
+            </div>
+          </div>
+
+          <!-- ── Stat Cards ── -->
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+            <!-- 総損益 -->
+            <div class="card stat-card">
+              <div class="card-body p-4">
+                <div class="flex items-center justify-between mb-3">
+                  <span class="text-sm text-secondary">総損益</span>
+                  <svg class="icon-base text-disabled" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M2 16L7 9l3 4 4-7 4-1V16z" />
+                  </svg>
+                </div>
+                <svg class="stat-spark text-success" viewBox="0 0 100 30" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" preserveAspectRatio="none">
+                  <path d="M2,26 C18,22 30,18 45,14 C58,10 70,8 98,4" />
+                </svg>
+                <p id="total-pnl" class="text-2xl font-bold mb-2">¥0</p>
+                <div class="flex items-center justify-between">
+                  <span class="text-xs text-secondary">累計</span>
                 </div>
               </div>
+            </div>
 
-              <!-- Metrics Grid -->
-              <div class="grid grid-cols-2 gap-4">
-                <div class="metric-card">
-                  <p class="text-xs text-secondary mb-2 uppercase tracking-wide">接続状態</p>
-                  <p id="credentials-status" class="text-xl font-black">-</p>
+            <!-- 本日損益 -->
+            <div class="card stat-card">
+              <div class="card-body p-4">
+                <div class="flex items-center justify-between mb-3">
+                  <span class="text-sm text-secondary">本日損益</span>
+                  <svg class="icon-base text-disabled" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M10 2a8 8 0 100 16A8 8 0 0010 2zm1 5H9v5l4 2.5-.75-1.23L11 12V7z" />
+                  </svg>
                 </div>
-                <div class="metric-card">
-                  <p class="text-xs text-secondary mb-2 uppercase tracking-wide">戦略</p>
-                  <p id="strategy" class="text-xl font-black">-</p>
+                <svg class="stat-spark text-info" viewBox="0 0 100 30" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" preserveAspectRatio="none">
+                  <path d="M2,24 C20,22 36,20 50,16 C64,12 78,10 98,6" />
+                </svg>
+                <p id="today-pnl" class="text-2xl font-bold mb-2">¥0</p>
+                <div class="flex items-center justify-between">
+                  <span class="text-xs text-secondary">本日</span>
                 </div>
-                <div class="metric-card">
-                  <p class="text-xs text-secondary mb-2 uppercase tracking-wide">総取引回数</p>
-                  <p id="total-trades" class="text-xl font-black">-</p>
+              </div>
+            </div>
+
+            <!-- 勝率 -->
+            <div class="card stat-card">
+              <div class="card-body p-4">
+                <div class="flex items-center justify-between mb-3">
+                  <span class="text-sm text-secondary">勝率</span>
+                  <svg class="icon-base text-disabled" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M10 2l2.4 7h7.6l-6 4.5 2.3 7-6.3-4.6L3.7 20.5 6 13.5 0 9h7.6z" />
+                  </svg>
                 </div>
-                <div class="metric-card">
-                  <p class="text-xs text-secondary mb-2 uppercase tracking-wide">稼働時間</p>
-                  <p id="uptime" class="text-xl font-black">-</p>
+                <svg class="stat-spark text-warning" viewBox="0 0 100 30" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" preserveAspectRatio="none">
+                  <path d="M2,22 C15,18 26,26 42,16 C56,8 72,6 98,4" />
+                </svg>
+                <p id="win-rate" class="text-2xl font-bold mb-2">0%</p>
+                <div class="flex items-center justify-between">
+                  <span class="text-xs text-secondary">勝率</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- 総取引回数 -->
+            <div class="card stat-card">
+              <div class="card-body p-4">
+                <div class="flex items-center justify-between mb-3">
+                  <span class="text-sm text-secondary">取引回数</span>
+                  <svg class="icon-base text-disabled" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M2 17V9h4v8H2zM8 17V5h4v12H8zM14 17v-6h4v6h-4z" />
+                  </svg>
+                </div>
+                <svg class="stat-spark text-primary" viewBox="0 0 100 30" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" preserveAspectRatio="none">
+                  <path d="M2,28 C18,24 32,20 48,15 C62,10 76,8 98,5" />
+                </svg>
+                <p id="total-trades" class="text-2xl font-bold mb-2">-</p>
+                <div class="flex items-center justify-between">
+                  <span class="text-xs text-secondary">累計</span>
                 </div>
               </div>
             </div>
           </div>
-        </div>
+          <!-- /stat cards -->
 
-        <!-- Performance -->
-        <div class="card glass transition-all duration-300 hover:shadow-xl h-96 max-h-96 flex flex-col overflow-hidden">
-          <div class="card-header border-b border-slate-200">
-            <h2 class="font-bold text-lg">パフォーマンス</h2>
-          </div>
-          <div class="card-body flex-1 min-h-0 overflow-y-auto">
-            <div class="space-y-4">
-              <div class="text-center p-5 glass rounded-lg mb-3 border-2 border-primary">
-                <p class="text-xs text-secondary mb-2 uppercase tracking-wide font-semibold">総損益</p>
-                <p id="total-pnl" class="text-4xl font-black">¥0</p>
+          <!-- ── Middle: 取引履歴 + システム状態 ── -->
+          <div class="grid md:grid-cols-3 gap-4 mb-6">
+            <!-- 取引履歴 (2/3) -->
+            <div class="card md:col-span-2 flex flex-col" style="max-height:380px;">
+              <div class="card-header">
+                <h2 class="text-base font-semibold">取引履歴</h2>
               </div>
-              <div class="grid grid-cols-2 gap-3">
-                <div class="text-center p-4 bg-white rounded-lg shadow-sm">
-                  <p class="text-xs text-secondary mb-2 uppercase tracking-wide">勝率</p>
-                  <p id="win-rate" class="text-2xl font-black">0%</p>
+              <div class="card-body flex-1 overflow-y-auto">
+                <table class="table table-sm w-full">
+                  <thead>
+                    <tr>
+                      <th>日時</th>
+                      <th>通貨ペア</th>
+                      <th>売買</th>
+                      <th class="text-right">価格</th>
+                      <th class="text-right">数量</th>
+                      <th class="text-right">手数料</th>
+                      <th class="text-right">損益</th>
+                    </tr>
+                  </thead>
+                  <tbody id="trades-table">
+                    <tr><td colspan="7" class="text-center text-secondary py-6">読み込み中...</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <!-- システム状態 (1/3) -->
+            <div class="flex flex-col gap-4">
+              <!-- 接続・稼働 -->
+              <div class="card">
+                <div class="card-header">
+                  <h2 class="text-base font-semibold">システム状態</h2>
                 </div>
-                <div class="text-center p-4 bg-white rounded-lg shadow-sm">
-                  <p class="text-xs text-secondary mb-2 uppercase tracking-wide">本日損益</p>
-                  <p id="today-pnl" class="text-2xl font-black">¥0</p>
+                <div class="card-body">
+                  <div class="grid grid-cols-2 gap-3 mb-3">
+                    <div>
+                      <p class="text-xs text-secondary mb-1">接続状態</p>
+                      <p id="credentials-status" class="text-sm font-bold">-</p>
+                    </div>
+                    <div>
+                      <p class="text-xs text-secondary mb-1">戦略</p>
+                      <p id="strategy" class="text-sm font-bold">-</p>
+                    </div>
+                    <div class="col-span-2">
+                      <p class="text-xs text-secondary mb-1">稼働時間</p>
+                      <p id="uptime" class="text-sm font-bold">-</p>
+                    </div>
+                  </div>
+                  <!-- 監視通貨ペア -->
+                  <p class="text-xs text-secondary mb-2">監視中の通貨ペア</p>
+                  <div id="monitoring-prices" class="space-y-1">
+                    <div class="text-center text-secondary py-2 text-xs">読み込み中...</div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </div>
 
-      <!-- Section 2: Balance, Orders, PnL History -->
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
-        <!-- Balance -->
-        <div class="card glass transition-all duration-300 hover:shadow-xl h-96 max-h-96 flex flex-col overflow-hidden">
-          <div class="card-header border-b border-slate-200">
-            <h2 class="font-bold text-lg">残高</h2>
-          </div>
-          <div class="card-body flex-1 min-h-0 overflow-y-auto">
-            <table class="table table-sm w-full">
-              <thead>
-                <tr class="border-b-2 border-slate-300">
-                  <th class="font-bold">通貨</th>
-                  <th class="text-right font-bold">総量</th>
-                  <th class="text-right font-bold">利用可能</th>
-                </tr>
-              </thead>
-              <tbody id="balance-table">
-                <tr><td colspan="3" class="text-center text-secondary py-6">読み込み中...</td></tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
+          <!-- ── Bottom: 残高 + 日別損益 ── -->
+          <div class="grid md:grid-cols-2 gap-4 mb-6">
+            <!-- 残高 -->
+            <div class="card flex flex-col" style="max-height:320px;">
+              <div class="card-header">
+                <h2 class="text-base font-semibold">残高</h2>
+              </div>
+              <div class="card-body flex-1 overflow-y-auto">
+                <table class="table table-sm w-full">
+                  <thead>
+                    <tr>
+                      <th>通貨</th>
+                      <th class="text-right">総量</th>
+                      <th class="text-right">利用可能</th>
+                    </tr>
+                  </thead>
+                  <tbody id="balance-table">
+                    <tr><td colspan="3" class="text-center text-secondary py-6">読み込み中...</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
 
-        <!-- PnL History -->
-        <div class="card glass transition-all duration-300 hover:shadow-xl h-96 max-h-96 flex flex-col overflow-hidden">
-          <div class="card-header border-b border-slate-200">
-            <h2 class="font-bold text-lg">日別損益</h2>
-          </div>
-          <div class="card-body flex-1 min-h-0 overflow-y-auto">
-              <table class="table table-sm w-full">
-              <thead>
-                <tr class="border-b-2 border-slate-300">
-                  <th class="font-bold">日付</th>
-                  <th class="text-right font-bold">損益</th>
-                  <th class="text-right font-bold">勝率</th>
-                  <th class="text-right font-bold">取引数</th>
-                </tr>
-              </thead>
-              <tbody id="pnl-history-table">
-                <tr>
-                  <td colspan="4" class="text-center text-secondary py-6">読み込み中...</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-
-      <!-- Section 3: Trade History and System Logs -->
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <!-- Trade History (Left Column) -->
-          <div class="card glass transition-all duration-300 hover:shadow-xl h-96 max-h-96 flex flex-col overflow-hidden">
-          <div class="card-header border-b border-slate-200">
-            <h2 class="font-bold text-lg">取引履歴</h2>
-          </div>
-          <div class="card-body flex-1 min-h-0 overflow-y-auto">
-              <table class="table table-sm w-full">
-                <thead>
-                  <tr class="border-b-2 border-slate-300">
-                    <th class="font-bold">日時</th>
-                    <th class="font-bold">通貨ペア</th>
-                    <th class="font-bold">売買</th>
-                    <th class="text-right font-bold">価格</th>
-                    <th class="text-right font-bold">数量</th>
-                    <th class="text-right font-bold">手数料</th>
-                    <th class="text-right font-bold">損益</th>
-                  </tr>
-                </thead>
-                <tbody id="trades-table">
-                  <tr>
-                    <td colspan="7" class="text-center text-secondary py-6">読み込み中...</td>
-                  </tr>
-                </tbody>
-              </table>
-          </div>
-        </div>
-
-          <!-- System Logs (Right Column) -->
-          <div class="card glass transition-all duration-300 hover:shadow-xl h-96 max-h-96 flex flex-col overflow-hidden">
-          <div class="card-header flex justify-between items-center border-b border-slate-200">
-            <h2 class="font-bold text-lg">システムログ</h2>
-            <div class="flex gap-2">
-              <select id="log-level-filter" class="form-select form-select-sm form-control w-auto transition-colors duration-200">
-                <option value="">全レベル</option>
-                <option value="DEBUG">デバッグ</option>
-                <option value="INFO">情報</option>
-                <option value="WARN">警告</option>
-                <option value="ERROR">エラー</option>
-              </select>
-              <select id="log-category-filter" class="form-select form-select-sm form-control w-auto transition-colors duration-200">
-                <option value="">全カテゴリ</option>
-                <option value="system">システム</option>
-                <option value="trading">取引</option>
-                <option value="api">API</option>
-                <option value="strategy">戦略</option>
-                <option value="ui">UI</option>
-                <option value="data">データ</option>
-              </select>
+            <!-- 日別損益 -->
+            <div class="card flex flex-col" style="max-height:320px;">
+              <div class="card-header">
+                <h2 class="text-base font-semibold">日別損益</h2>
+              </div>
+              <div class="card-body flex-1 overflow-y-auto">
+                <table class="table table-sm w-full">
+                  <thead>
+                    <tr>
+                      <th>日付</th>
+                      <th class="text-right">損益</th>
+                      <th class="text-right">勝率</th>
+                      <th class="text-right">取引数</th>
+                    </tr>
+                  </thead>
+                  <tbody id="pnl-history-table">
+                    <tr><td colspan="4" class="text-center text-secondary py-6">読み込み中...</td></tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
-          <div class="card-body flex-1 min-h-0 overflow-y-auto">
-            <div id="logs-container" class="space-y-1 font-mono text-xs">
-              <div class="text-center text-secondary py-6">読み込み中...</div>
+
+          <!-- ── Logs ── -->
+          <div class="card">
+            <div class="card-header">
+              <div class="flex items-center justify-between flex-wrap gap-2">
+                <h2 class="text-base font-semibold">システムログ</h2>
+                <div class="flex gap-2">
+                  <select id="log-level-filter" class="form-control form-select form-select-sm w-auto">
+                    <option value="">全レベル</option>
+                    <option value="DEBUG">デバッグ</option>
+                    <option value="INFO">情報</option>
+                    <option value="WARN">警告</option>
+                    <option value="ERROR">エラー</option>
+                  </select>
+                  <select id="log-category-filter" class="form-control form-select form-select-sm w-auto">
+                    <option value="">全カテゴリ</option>
+                    <option value="system">システム</option>
+                    <option value="trading">取引</option>
+                    <option value="api">API</option>
+                    <option value="strategy">戦略</option>
+                    <option value="ui">UI</option>
+                    <option value="data">データ</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div class="card-body" style="max-height:320px;overflow-y:auto;">
+              <div id="logs-container" class="space-y-1 font-mono text-xs">
+                <div class="text-center text-secondary py-6">読み込み中...</div>
+              </div>
             </div>
           </div>
-        </div>
-      </div>
-    </main>
 
-    <script src="script.js?v=20260227"></script>
+        </div>
+        <!-- /dashboard-content -->
+      </div>
+      <!-- /dashboard-main -->
+    </div>
+    <!-- /dashboard -->
+
+    <script src="script.js?v=20260318"></script>
   </body>
+</html>
 </html>


### PR DESCRIPTION
## Overview

Rebuild the gogocoin dashboard UI using the sleyt admin-dashboard layout pattern (https://bmf-san.github.io/sleyt/admin-dashboard.html).

## Changes

### CDN
- `sleyt@1.2.0` (jsDelivr) → `sleyt@latest` (unpkg)

### Layout
Before: header + flat card grid

After: **admin-dashboard pattern**
- `.sidebar` — vertical nav with trading status in footer
- `.topbar` — top bar with start/stop buttons
- `.dashboard-content` — main content area

### Content Structure
1. **4 stat-cards** (with sparklines): Total P&L / Today's P&L / Win Rate / Trade Count
2. **Middle row**: Trade history table (2/3) + System status panel (1/3)
3. **Bottom row**: Balance table + Daily P&L table
4. **Logs**: Full-width with level/category filters

### Compatibility
All element IDs referenced by `script.js` are unchanged.
