### PR TITLE
fix: add security-events write permission and upgrade codeql-action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
 
     steps:
     - name: Checkout code
@@ -134,7 +136,7 @@ jobs:
 
     - name: Upload SARIF file
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: results.sarif
 


### PR DESCRIPTION
## Problem

The `Security Scan` CI job has been failing with:

```
Resource not accessible by integration
```

This is caused by two issues:
1. The `security` job was missing `permissions: security-events: write`, which is required for the CodeQL SARIF upload step to access the GitHub Code Scanning API.
2. `github/codeql-action/upload-sarif@v3` is deprecated and will be removed in December 2026.

## Changes

- Add `permissions: security-events: write` to the `security` job
- Upgrade `github/codeql-action/upload-sarif` from `v3` to `v4`