### PR TITLE
fix: update trading status badge selector for new sidebar layout

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -178,14 +178,14 @@ class GogocoinUI {
         const stopBtn = document.getElementById('stop-trading-btn');
 
         if (tradingStatusBadge) {
-            const statusText = tradingStatusBadge.querySelector('p:last-child');
+            const statusText = tradingStatusBadge.querySelector('p.font-semibold');
             if (statusText) {
                 if (status.trading_enabled) {
                     statusText.textContent = '取引中';
-                    tradingStatusBadge.className = 'p-3 glass rounded-lg text-center border-2 border-success bg-success bg-opacity-10 mb-3';
+                    statusText.className = 'text-sm font-semibold leading-tight text-success';
                 } else {
                     statusText.textContent = '停止中';
-                    tradingStatusBadge.className = 'p-3 glass rounded-lg text-center border-2 border-slate-300 mb-3';
+                    statusText.className = 'text-sm font-semibold leading-tight';
                 }
             }
         }


### PR DESCRIPTION
## Problem

After the dashboard redesign (#14), the trading status badge in the sidebar stopped updating when the start/stop buttons were clicked.

**Root cause:** `script.js` used `querySelector('p:last-child')` to find the status text inside `#trading-status-badge`. In the old layout this was a direct child `<p>`, but in the new `sidebar-user` structure the `<p>` is nested deeper and `p:last-child` no longer matched — so the text never changed.

Additionally, `tradingStatusBadge.className = '...'` was overwriting the entire class string, which would have destroyed the `sidebar-user` layout classes.

## Fix

- Change selector from `p:last-child` to `p.font-semibold` (which uniquely identifies the status text within `#trading-status-badge`)
- Replace full `className` overwrite with a targeted `text-success` class toggle on the status `<p>` element only
