### PR TITLE
fix: remove static sparkline SVGs from stat cards

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -99,13 +99,8 @@
                     <path d="M2 16L7 9l3 4 4-7 4-1V16z" />
                   </svg>
                 </div>
-                <svg class="stat-spark text-success" viewBox="0 0 100 30" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" preserveAspectRatio="none">
-                  <path d="M2,26 C18,22 30,18 45,14 C58,10 70,8 98,4" />
-                </svg>
-                <p id="total-pnl" class="text-2xl font-bold mb-2">¥0</p>
-                <div class="flex items-center justify-between">
-                  <span class="text-xs text-secondary">累計</span>
-                </div>
+                <p id="total-pnl" class="text-2xl font-bold mb-1">¥0</p>
+                <span class="text-xs text-secondary">累計</span>
               </div>
             </div>
 
@@ -118,13 +113,8 @@
                     <path d="M10 2a8 8 0 100 16A8 8 0 0010 2zm1 5H9v5l4 2.5-.75-1.23L11 12V7z" />
                   </svg>
                 </div>
-                <svg class="stat-spark text-info" viewBox="0 0 100 30" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" preserveAspectRatio="none">
-                  <path d="M2,24 C20,22 36,20 50,16 C64,12 78,10 98,6" />
-                </svg>
-                <p id="today-pnl" class="text-2xl font-bold mb-2">¥0</p>
-                <div class="flex items-center justify-between">
-                  <span class="text-xs text-secondary">本日</span>
-                </div>
+                <p id="today-pnl" class="text-2xl font-bold mb-1">¥0</p>
+                <span class="text-xs text-secondary">本日</span>
               </div>
             </div>
 
@@ -137,13 +127,8 @@
                     <path fill-rule="evenodd" d="M10 2l2.4 7h7.6l-6 4.5 2.3 7-6.3-4.6L3.7 20.5 6 13.5 0 9h7.6z" />
                   </svg>
                 </div>
-                <svg class="stat-spark text-warning" viewBox="0 0 100 30" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" preserveAspectRatio="none">
-                  <path d="M2,22 C15,18 26,26 42,16 C56,8 72,6 98,4" />
-                </svg>
-                <p id="win-rate" class="text-2xl font-bold mb-2">0%</p>
-                <div class="flex items-center justify-between">
-                  <span class="text-xs text-secondary">勝率</span>
-                </div>
+                <p id="win-rate" class="text-2xl font-bold mb-1">0%</p>
+                <span class="text-xs text-secondary">勝率</span>
               </div>
             </div>
 
@@ -156,13 +141,8 @@
                     <path d="M2 17V9h4v8H2zM8 17V5h4v12H8zM14 17v-6h4v6h-4z" />
                   </svg>
                 </div>
-                <svg class="stat-spark text-primary" viewBox="0 0 100 30" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" preserveAspectRatio="none">
-                  <path d="M2,28 C18,24 32,20 48,15 C62,10 76,8 98,5" />
-                </svg>
-                <p id="total-trades" class="text-2xl font-bold mb-2">-</p>
-                <div class="flex items-center justify-between">
-                  <span class="text-xs text-secondary">累計</span>
-                </div>
+                <p id="total-trades" class="text-2xl font-bold mb-1">-</p>
+                <span class="text-xs text-secondary">累計</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Remove the four `stat-spark` SVGs from stat cards. They were hardcoded decorative paths with no connection to real trade data, creating a misleading impression of actual trends. Simplified card markup to just show the metric value and label.