### PR TITLE
fix: remove topbar search area (static placeholder text)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -67,12 +67,6 @@
         <!-- Topbar -->
         <header class="topbar">
           <label for="sidebar-toggle" class="sidebar-toggle-label" aria-label="Toggle sidebar">☰</label>
-          <div class="topbar-search">
-            <svg class="icon-sm" viewBox="0 0 20 20" fill="currentColor">
-              <path d="M2 17V7l8-5 8 5v10h-5v-6H7v6z" />
-            </svg>
-            gogocoin トレーディングダッシュボード
-          </div>
           <div class="flex items-center gap-2">
             <button id="start-trading-btn" class="btn btn-success btn-sm">開始</button>
             <button id="stop-trading-btn" class="btn btn-danger btn-sm hidden">停止</button>


### PR DESCRIPTION
Remove the `.topbar-search` div (which only showed static placeholder text "gogocoin トレーディングダッシュボード") from the topbar. The topbar now contains only the sidebar toggle and start/stop buttons.