### PR TITLE
fix: compute total P&L from all trades instead of last 1000

### DIFF
--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -4,6 +4,7 @@ package domain
 type TradeRepository interface {
 	SaveTrade(trade *Trade) error
 	GetRecentTrades(limit int) ([]Trade, error)
+	GetAllTrades() ([]Trade, error)
 }
 
 // PositionRepository is the interface for position data persistence

--- a/internal/infra/persistence/repository.go
+++ b/internal/infra/persistence/repository.go
@@ -40,6 +40,9 @@ func (r *Repository) SaveTrade(trade *domain.Trade) error {
 func (r *Repository) GetRecentTrades(limit int) ([]domain.Trade, error) {
 	return r.trade.GetRecentTrades(limit)
 }
+func (r *Repository) GetAllTrades() ([]domain.Trade, error) {
+	return r.trade.GetAllTrades()
+}
 func (r *Repository) GetTradesCount() (int, error) {
 	return r.trade.GetTradesCount()
 }

--- a/internal/infra/persistence/trade_repo.go
+++ b/internal/infra/persistence/trade_repo.go
@@ -65,6 +65,29 @@ func (r *TradeRepository) GetRecentTrades(limit int) ([]domain.Trade, error) {
 	return trades, rows.Err()
 }
 
+// GetAllTrades returns all trades ordered by executed_at ASC.
+func (r *TradeRepository) GetAllTrades() ([]domain.Trade, error) {
+	query := `SELECT id, symbol, side, type, size, price, fee, status, order_id,
+			  executed_at, created_at, updated_at, strategy_name, pnl
+			  FROM trades ORDER BY executed_at ASC`
+	rows, err := r.db.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+	var trades []domain.Trade
+	for rows.Next() {
+		var t domain.Trade
+		if err := rows.Scan(&t.ID, &t.Symbol, &t.Side, &t.Type, &t.Size, &t.Price, &t.Fee,
+			&t.Status, &t.OrderID, &t.ExecutedAt, &t.CreatedAt,
+			&t.UpdatedAt, &t.StrategyName, &t.PnL); err != nil {
+			return nil, err
+		}
+		trades = append(trades, t)
+	}
+	return trades, rows.Err()
+}
+
 // GetTradesCount returns the total number of trade records.
 func (r *TradeRepository) GetTradesCount() (int, error) {
 	var count int

--- a/internal/usecase/analytics/performance.go
+++ b/internal/usecase/analytics/performance.go
@@ -30,6 +30,7 @@ var _ PerformanceAnalyticsService = (*PerformanceAnalytics)(nil)
 // TradingRepository defines database operations for trades
 type TradingRepository interface {
 	GetRecentTrades(limit int) ([]domain.Trade, error)
+	GetAllTrades() ([]domain.Trade, error)
 }
 
 // AnalyticsRepository defines database operations for metrics
@@ -59,13 +60,13 @@ func (pa *PerformanceAnalytics) UpdateMetrics(ctx context.Context) error {
 		pa.logger.System().Debug("Calculating performance metrics")
 	}
 
-	// Get recent trading data
-	trades, err := pa.tradingRepo.GetRecentTrades(1000) // Maximum 1000 trades
+	// Get all trades for accurate cumulative P&L
+	trades, err := pa.tradingRepo.GetAllTrades()
 	if err != nil {
 		if pa.logger != nil {
-			pa.logger.System().WithError(err).Error("Failed to get recent trades for performance calculation")
+			pa.logger.System().WithError(err).Error("Failed to get all trades for performance calculation")
 		}
-		return fmt.Errorf("failed to get recent trades for performance calculation: %w", err)
+		return fmt.Errorf("failed to get all trades for performance calculation: %w", err)
 	}
 
 	if len(trades) == 0 {

--- a/internal/usecase/analytics/performance_test.go
+++ b/internal/usecase/analytics/performance_test.go
@@ -21,6 +21,10 @@ func (m *mockTradingRepo) GetRecentTrades(limit int) ([]domain.Trade, error) {
 	return m.trades[:limit], nil
 }
 
+func (m *mockTradingRepo) GetAllTrades() ([]domain.Trade, error) {
+	return m.trades, nil
+}
+
 type mockAnalyticsRepo struct {
 	savedMetrics []*domain.PerformanceMetric
 }

--- a/internal/usecase/trading/pnl/calculator_test.go
+++ b/internal/usecase/trading/pnl/calculator_test.go
@@ -46,6 +46,10 @@ func (m *mockTradingRepo) GetRecentTrades(limit int) ([]domain.Trade, error) {
 	return nil, nil
 }
 
+func (m *mockTradingRepo) GetAllTrades() ([]domain.Trade, error) {
+	return nil, nil
+}
+
 func (m *mockTradingRepo) SavePosition(p *domain.Position) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Problem

`UpdateMetrics` was calling `GetRecentTrades(1000)`, which meant the `total_pnl` stored in `performance_metrics` only reflected the last 1000 trades. With active trading, this could represent less than a day of history — not a true cumulative figure.

## Solution

Add `GetAllTrades()` to:
- `domain.TradeRepository` interface
- `persistence.TradeRepository` implementation (same query as `GetRecentTrades` but without `LIMIT`)
- `persistence.Repository` delegate
- `analytics.TradingRepository` local interface

Update `UpdateMetrics` to call `GetAllTrades()` instead of `GetRecentTrades(1000)`.

With `data_retention.retention_days: 7` the DB holds at most ~7 days of trades, so a full scan remains inexpensive.

## Tests

- Updated `mockTradingRepo` in `performance_test.go` to satisfy the new interface
- All 20 analytics tests pass