### PR TITLE
fix: correct JST P&L calculation and sidebar navigation

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -20,26 +20,25 @@
         </a>
 
         <nav class="sidebar-nav">
-          <span class="sidebar-section-label">メイン</span>
-          <a href="#" class="sidebar-link active">
+          <a href="#" class="sidebar-link active" data-target="section-overview">
             <svg class="sidebar-link-icon" viewBox="0 0 20 20" fill="currentColor">
               <path d="M10 2L2 9h2v9h4v-5h4v5h4V9h2L10 2z" />
             </svg>
             ダッシュボード
           </a>
-          <a href="#" class="sidebar-link">
+          <a href="#" class="sidebar-link" data-target="section-performance">
             <svg class="sidebar-link-icon" viewBox="0 0 20 20" fill="currentColor">
               <path d="M2 17V9h4v8H2zM8 17V5h4v12H8zM14 17v-6h4v6h-4z" />
             </svg>
             パフォーマンス
           </a>
-          <a href="#" class="sidebar-link">
+          <a href="#" class="sidebar-link" data-target="section-trades">
             <svg class="sidebar-link-icon" viewBox="0 0 20 20" fill="currentColor">
               <path d="M5 3h10v2H5zM3 7h14v2H3zM1 11h18v8H1z" />
             </svg>
             取引履歴
           </a>
-          <a href="#" class="sidebar-link">
+          <a href="#" class="sidebar-link" data-target="section-logs">
             <svg class="sidebar-link-icon" viewBox="0 0 20 20" fill="currentColor">
               <path fill-rule="evenodd" d="M10 2a8 8 0 100 16A8 8 0 0010 2zM9 5h2v2H9zM9 8h2v6H9z" />
             </svg>
@@ -83,7 +82,7 @@
           </div>
 
           <!-- ── Stat Cards ── -->
-          <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+          <div id="section-overview" class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
             <!-- 総損益 -->
             <div class="card stat-card">
               <div class="card-body p-4">
@@ -143,7 +142,7 @@
           <!-- /stat cards -->
 
           <!-- ── Middle: 取引履歴 + システム状態 ── -->
-          <div class="grid md:grid-cols-3 gap-4 mb-6">
+          <div id="section-trades" class="grid md:grid-cols-3 gap-4 mb-6">
             <!-- 取引履歴 (2/3) -->
             <div class="card md:col-span-2 flex flex-col">
               <div class="card-header">
@@ -202,7 +201,7 @@
           </div>
 
           <!-- ── Bottom: 残高 + 日別損益 ── -->
-          <div class="grid md:grid-cols-2 gap-4 mb-6">
+          <div id="section-performance" class="grid md:grid-cols-2 gap-4 mb-6">
             <!-- 残高 -->
             <div class="card flex flex-col">
               <div class="card-header">
@@ -248,7 +247,7 @@
           </div>
 
           <!-- ── Logs ── -->
-          <div class="card">
+          <div id="section-logs" class="card">
             <div class="card-header">
               <div class="flex items-center justify-between flex-wrap gap-2">
                 <h2 class="text-base font-semibold">システムログ</h2>

--- a/web/script.js
+++ b/web/script.js
@@ -43,6 +43,19 @@ class GogocoinUI {
             this.loadLogs();
         });
 
+        // Sidebar navigation
+        document.querySelectorAll('.sidebar-link[data-target]').forEach(link => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const target = document.getElementById(link.dataset.target);
+                if (target) {
+                    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+                document.querySelectorAll('.sidebar-link').forEach(l => l.classList.remove('active'));
+                link.classList.add('active');
+            });
+        });
+
         // Trading control button event listeners
         const startBtn = document.getElementById('start-trading-btn');
         const stopBtn = document.getElementById('stop-trading-btn');

--- a/web/script.js
+++ b/web/script.js
@@ -109,7 +109,7 @@ class GogocoinUI {
                 this.fetchAPI(`/api/status?symbol=${this.selectedSymbol}`),
                 this.fetchAPI('/api/balance'),
                 this.fetchAPI('/api/performance'),
-                this.fetchAPI('/api/trades?limit=50')
+                this.fetchAPI('/api/trades?limit=200')
             ]);
 
             const [statusResult, balanceResult, performanceResult, tradesResult] = results;
@@ -321,15 +321,13 @@ class GogocoinUI {
 
         // Calculate today's PnL from actual trade records (JST date match)
         if (todayPnlEl) {
-            const jstOffset = 9 * 60;
-            const now = new Date(Date.now() + (jstOffset + new Date().getTimezoneOffset()) * 60000);
-            const today = now.toISOString().split('T')[0];
+            const jstOffsetMs = 9 * 60 * 60 * 1000;
+            const today = new Date(Date.now() + jstOffsetMs).toISOString().split('T')[0];
             let todayPnL = 0;
             let hasTodayTrades = false;
             (trades || []).forEach(t => {
                 if (!t.executed_at) return;
-                const d = new Date(t.executed_at);
-                const jstDate = new Date(d.getTime() + (jstOffset + d.getTimezoneOffset()) * 60000)
+                const jstDate = new Date(new Date(t.executed_at).getTime() + jstOffsetMs)
                     .toISOString().split('T')[0];
                 if (jstDate === today && t.pnl !== undefined && t.pnl !== null) {
                     todayPnL += t.pnl;


### PR DESCRIPTION
## Changes

### fix: correct JST date comparison for today's P\&L calculation (#script.js)

`getTimezoneOffset()` was cancelling out the JST offset when the browser
runs in JST (UTC+9), causing UTC dates to be compared instead of JST dates.
Trades before 09:00 JST (< 00:00 UTC) were excluded from today's P\&L.

Fix: use a fixed 9-hour offset (`jstOffsetMs`) independent of browser timezone.
Also increase trade fetch limit from 50 to 200 to ensure all of today's
trades are included.

### fix: remove sidebar メイン label and enable nav link scrolling (#index.html)

- Remove redundant sidebar-section-label 'メイン'
- Add `data-target` attributes to sidebar links
- Add section IDs: `section-overview`, `section-trades`, `section-performance`, `section-logs`
- Implement smooth scroll + active state toggle on sidebar link click