### PR TITLE
fix: sidebar nav - close mobile overlay and fix scroll container

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -47,12 +47,19 @@ class GogocoinUI {
         document.querySelectorAll('.sidebar-link[data-target]').forEach(link => {
             link.addEventListener('click', (e) => {
                 e.preventDefault();
-                const target = document.getElementById(link.dataset.target);
-                if (target) {
-                    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }
+                // Update active state
                 document.querySelectorAll('.sidebar-link').forEach(l => l.classList.remove('active'));
                 link.classList.add('active');
+                // Close sidebar on mobile
+                const toggle = document.getElementById('sidebar-toggle');
+                if (toggle) toggle.checked = false;
+                // Scroll to section
+                const target = document.getElementById(link.dataset.target);
+                if (target) {
+                    const scrollEl = document.querySelector('.dashboard-main') || document.documentElement;
+                    const offset = target.getBoundingClientRect().top - scrollEl.getBoundingClientRect().top + scrollEl.scrollTop;
+                    scrollEl.scrollTo({ top: offset, behavior: 'smooth' });
+                }
             });
         });
 


### PR DESCRIPTION
## Problem

- On mobile, clicking a sidebar link did not close the sidebar overlay
- `scrollIntoView()` was not correctly targeting the scroll container

## Solution

- Close sidebar on link click by unchecking `#sidebar-toggle`
- Replace `scrollIntoView` with explicit `scrollTo` on `.dashboard-main` container for reliable scroll behavior
- Active state is now set before scroll