### PR TITLE
fix: implement WebSocket reconnect in marketDataAdapter

### DIFF
--- a/internal/infra/exchange/bitflyer/client.go
+++ b/internal/infra/exchange/bitflyer/client.go
@@ -153,6 +153,20 @@ func (c *Client) SetDisconnected() {
 	c.mu.Unlock()
 }
 
+// Reconnect closes the existing WebSocket connection and establishes a new one.
+// Callers should also call MarketDataService.ResetCallbacks() after this.
+func (c *Client) Reconnect(ctx context.Context) error {
+	c.mu.Lock()
+	if c.wsClient != nil {
+		c.wsClient.Close(ctx)
+		c.wsClient = nil
+	}
+	c.isConnected = false
+	c.mu.Unlock()
+
+	return c.initWebSocketClient()
+}
+
 // Close closes the client
 func (c *Client) Close(ctx context.Context) error {
 	c.mu.Lock()

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -348,7 +348,14 @@ type marketDataAdapter struct {
 }
 
 func (m *marketDataAdapter) IsConnected() bool { return m.client.IsConnected() }
-func (m *marketDataAdapter) ReconnectClient() error { return nil }
+func (m *marketDataAdapter) ReconnectClient() error {
+	ctx := context.Background()
+	if err := m.client.Reconnect(ctx); err != nil {
+		return fmt.Errorf("websocket reconnect failed: %w", err)
+	}
+	m.marketDataSvc.ResetCallbacks()
+	return nil
+}
 func (m *marketDataAdapter) SubscribeToTicker(ctx context.Context, symbol string, callback func(domain.MarketData)) error {
 	return m.marketDataSvc.SubscribeToTicker(ctx, symbol, func(bfd bitflyer.MarketData) {
 		callback(domain.MarketData{


### PR DESCRIPTION
## Problem

After a WebSocket reconnection event, market data stops flowing indefinitely due to an infinite "channel already subscribed" error loop, which also prevents stop-loss from triggering during sharp price drops.

**Root cause:** `marketDataAdapter.ReconnectClient()` in `pkg/engine/engine.go` was a no-op stub (`return nil`).

When a stale/broken WebSocket was detected:
1. `ReconnectClient()` was called → did nothing, returned nil
2. Worker thought reconnection succeeded
3. `SubscribeToTicker()` was called again → `wsClient.Subscribe()` failed with `"channel X already subscribed"` (because the old WS state with `callbacksInit=true` was intact)
4. `subscribedCount == 0` → 10-second wait → back to step 3
5. This looped forever — no market data, no stop-loss

**Observed in issue #39 (2026-03-18):** WebSocket disconnect at 21:17 JST caused a 10-minute loop. XRP dropped from ¥244 to ¥232 (~5%) during the outage. Three positions were closed at a loss of ¥-11.40, ¥-10.70, ¥-11.85 because stop-loss had no market data to work with.

## Fix

### 1. `internal/infra/exchange/bitflyer/client.go`
Added `Reconnect(ctx context.Context) error` that:
- Closes the existing WebSocket connection
- Calls `initWebSocketClient()` to establish a fresh connection

### 2. `pkg/engine/engine.go`
Implemented `marketDataAdapter.ReconnectClient()` to:
- Call `client.Reconnect(ctx)` for a clean WebSocket
- Call `marketDataSvc.ResetCallbacks()` to clear `callbacksInit` and stale handler state, so the next `SubscribeToTicker` call registers fresh subscriptions without hitting "already subscribed"

## Testing

- `go build ./...` passes
- `go test ./internal/adapter/worker/... ./internal/infra/exchange/bitflyer/...` passes