### PR TITLE
feat(web): add risk metrics display + fix multiple trading bugs

### DIFF
--- a/internal/adapter/http/handler_control.go
+++ b/internal/adapter/http/handler_control.go
@@ -13,7 +13,7 @@ func internalErr(msg string) InternalServerErrorJSONResponse {
 	return InternalServerErrorJSONResponse{Message: &msg}
 }
 
-// PostApiTradingStart implements StrictServerInterface - 取引開始
+// PostApiTradingStart implements StrictServerInterface - start trading
 func (s *Server) PostApiTradingStart(ctx context.Context, request PostApiTradingStartRequestObject) (PostApiTradingStartResponseObject, error) {
 	s.logger.UI().Info("Trading start requested via API")
 
@@ -48,7 +48,7 @@ func (s *Server) PostApiTradingStart(ctx context.Context, request PostApiTrading
 	}, nil
 }
 
-// PostApiTradingStop implements StrictServerInterface - 取引停止
+// PostApiTradingStop implements StrictServerInterface - stop trading
 func (s *Server) PostApiTradingStop(ctx context.Context, request PostApiTradingStopRequestObject) (PostApiTradingStopResponseObject, error) {
 	s.logger.UI().Info("Trading stop requested via API")
 
@@ -83,7 +83,7 @@ func (s *Server) PostApiTradingStop(ctx context.Context, request PostApiTradingS
 	}, nil
 }
 
-// GetApiTradingStatus implements StrictServerInterface - 取引状態の取得
+// GetApiTradingStatus implements StrictServerInterface - get trading status
 func (s *Server) GetApiTradingStatus(ctx context.Context, request GetApiTradingStatusRequestObject) (GetApiTradingStatusResponseObject, error) {
 	if s.app == nil {
 		return GetApiTradingStatus503JSONResponse{svcUnavailableErr("Application not initialized")}, nil
@@ -110,7 +110,7 @@ func (s *Server) GetApiTradingStatus(ctx context.Context, request GetApiTradingS
 	}, nil
 }
 
-// PostApiStrategyReset implements StrictServerInterface - 戦略状態のリセット
+// PostApiStrategyReset implements StrictServerInterface - reset strategy state
 func (s *Server) PostApiStrategyReset(ctx context.Context, request PostApiStrategyResetRequestObject) (PostApiStrategyResetResponseObject, error) {
 	s.logger.UI().Info("Strategy reset requested via API")
 

--- a/internal/adapter/http/handler_data.go
+++ b/internal/adapter/http/handler_data.go
@@ -53,7 +53,7 @@ func maskedConfig(cfg *config.Config) *config.Config {
 	return &copy
 }
 
-// GetApiBalance implements StrictServerInterface - 残高取得
+// GetApiBalance implements StrictServerInterface - get balance
 func (s *Server) GetApiBalance(ctx context.Context, request GetApiBalanceRequestObject) (GetApiBalanceResponseObject, error) {
 	if s.app != nil {
 		balances, err := s.app.GetBalances(ctx)
@@ -101,7 +101,7 @@ func (s *Server) GetApiBalance(ctx context.Context, request GetApiBalanceRequest
 	return GetApiBalance200JSONResponse(domainBalancesToAPI(balances)), nil
 }
 
-// GetApiTrades implements StrictServerInterface - 取引履歴の取得
+// GetApiTrades implements StrictServerInterface - get trade history
 func (s *Server) GetApiTrades(ctx context.Context, request GetApiTradesRequestObject) (GetApiTradesResponseObject, error) {
 	limit := 50
 	if request.Params.Limit != nil {
@@ -119,7 +119,7 @@ func (s *Server) GetApiTrades(ctx context.Context, request GetApiTradesRequestOb
 	return GetApiTrades200JSONResponse(domainTradesToAPI(trades)), nil
 }
 
-// GetApiPerformance implements StrictServerInterface - パフォーマンス指標の取得
+// GetApiPerformance implements StrictServerInterface - get performance metrics
 func (s *Server) GetApiPerformance(ctx context.Context, request GetApiPerformanceRequestObject) (GetApiPerformanceResponseObject, error) {
 	metrics, err := s.db.GetPerformanceMetrics(30)
 	if err != nil {
@@ -132,13 +132,13 @@ func (s *Server) GetApiPerformance(ctx context.Context, request GetApiPerformanc
 	return GetApiPerformance200JSONResponse(domainMetricsToAPI(metrics)), nil
 }
 
-// GetApiConfig implements StrictServerInterface - 現在の設定を取得
+// GetApiConfig implements StrictServerInterface - get current config
 func (s *Server) GetApiConfig(ctx context.Context, request GetApiConfigRequestObject) (GetApiConfigResponseObject, error) {
 	s.logger.UI().WithField("strategy", s.config.Trading.Strategy.Name).Info("Returning config")
 	return customConfigResponse{cfg: maskedConfig(s.config)}, nil
 }
 
-// PostApiConfig implements StrictServerInterface - 設定を更新
+// PostApiConfig implements StrictServerInterface - update config
 func (s *Server) PostApiConfig(ctx context.Context, request PostApiConfigRequestObject) (PostApiConfigResponseObject, error) {
 	if request.Body == nil {
 		msg := "Request body is required"
@@ -189,7 +189,7 @@ func (s *Server) PostApiConfig(ctx context.Context, request PostApiConfigRequest
 	return customConfigUpdateResponse{cfg: maskedConfig(s.config), message: "Configuration saved"}, nil
 }
 
-// GetApiLogs implements StrictServerInterface - ログの取得
+// GetApiLogs implements StrictServerInterface - get logs
 func (s *Server) GetApiLogs(ctx context.Context, request GetApiLogsRequestObject) (GetApiLogsResponseObject, error) {
 	limit := 100
 	if request.Params.Limit != nil {
@@ -216,7 +216,7 @@ func (s *Server) GetApiLogs(ctx context.Context, request GetApiLogsRequestObject
 	return GetApiLogs200JSONResponse(domainLogsToAPI(logs)), nil
 }
 
-// GetApiOrders implements StrictServerInterface - 注文履歴の取得
+// GetApiOrders implements StrictServerInterface - get order history
 func (s *Server) GetApiOrders(ctx context.Context, request GetApiOrdersRequestObject) (GetApiOrdersResponseObject, error) {
 	// Orders are not stored in DB directly; return empty list
 	return GetApiOrders200JSONResponse{}, nil
@@ -381,6 +381,3 @@ func domainLogsToAPI(logs []domain.LogEntry) []LogEntry {
 	}
 	return result
 }
-
-
-

--- a/internal/adapter/http/handler_status.go
+++ b/internal/adapter/http/handler_status.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// GetHealth implements StrictServerInterface - ヘルスチェック
+// GetHealth implements StrictServerInterface - health check
 func (s *Server) GetHealth(ctx context.Context, request GetHealthRequestObject) (GetHealthResponseObject, error) {
 	now := time.Now()
 	uptime := s.calculateUptime()
@@ -19,7 +19,7 @@ func (s *Server) GetHealth(ctx context.Context, request GetHealthRequestObject) 
 	}, nil
 }
 
-// GetApiStatus implements StrictServerInterface - システム状態の取得
+// GetApiStatus implements StrictServerInterface - get system status
 func (s *Server) GetApiStatus(ctx context.Context, request GetApiStatusRequestObject) (GetApiStatusResponseObject, error) {
 	const (
 		APIKeyPlaceholder    = "${BITFLYER_API_KEY}"

--- a/internal/infra/exchange/bitflyer/client.go
+++ b/internal/infra/exchange/bitflyer/client.go
@@ -296,6 +296,7 @@ type RateLimiter struct {
 	requests chan struct{}
 	ticker   *time.Ticker
 	done     chan struct{} // Signal to stop the goroutine
+	stopOnce sync.Once   // Ensures Stop() is safe to call more than once
 }
 
 // NewRateLimiter creates a new rate limiter
@@ -348,10 +349,12 @@ func (rl *RateLimiter) Wait(ctx context.Context) error {
 	}
 }
 
-// Stop stops the rate limiter
+// Stop stops the rate limiter. Safe to call multiple times.
 func (rl *RateLimiter) Stop() {
-	rl.ticker.Stop()
-	close(rl.done) // Signal goroutine to stop
+	rl.stopOnce.Do(func() {
+		rl.ticker.Stop()
+		close(rl.done) // Signal goroutine to stop
+	})
 }
 
 // RetryPolicy defines retry policy

--- a/internal/infra/exchange/bitflyer/client.go
+++ b/internal/infra/exchange/bitflyer/client.go
@@ -296,7 +296,7 @@ type RateLimiter struct {
 	requests chan struct{}
 	ticker   *time.Ticker
 	done     chan struct{} // Signal to stop the goroutine
-	stopOnce sync.Once   // Ensures Stop() is safe to call more than once
+	stopOnce sync.Once     // Ensures Stop() is safe to call more than once
 }
 
 // NewRateLimiter creates a new rate limiter

--- a/internal/usecase/risk/manager.go
+++ b/internal/usecase/risk/manager.go
@@ -219,6 +219,17 @@ func (rm *Manager) checkTotalLossLimit(ctx context.Context) error {
 		}
 	}
 
+	// If JPY balance is zero (all capital is deployed in crypto),
+	// fall back to InitialBalance to avoid a division-by-zero that would
+	// produce +Inf and incorrectly block SELL orders.
+	if totalAssets <= 0 {
+		totalAssets = rm.cfg.InitialBalance
+	}
+	if totalAssets <= 0 {
+		// InitialBalance also zero — cannot evaluate loss percentage, skip check.
+		return nil
+	}
+
 	// Calculate loss percentage against current assets.
 	// totalLoss is the absolute loss value; totalAssets is the current balance.
 	lossPercent := (totalLoss / totalAssets) * 100

--- a/internal/usecase/risk/manager.go
+++ b/internal/usecase/risk/manager.go
@@ -76,14 +76,16 @@ func (rm *Manager) CheckRiskManagement(ctx context.Context, signal *strategy.Sig
 		}
 	}
 
-	// Validate balance before risk checks
-	if totalBalanceJPY <= 0 {
-		return fmt.Errorf("insufficient JPY balance for risk check: %f", totalBalanceJPY)
-	}
-
-	// Check trade amount (including fees)
-	if err := rm.checkTradeAmount(signal, totalBalanceJPY); err != nil {
-		return fmt.Errorf("trade amount validation failed: %w", err)
+	// BUY orders require positive JPY balance and are subject to the trade-amount
+	// cap.  SELL orders liquidate crypto holdings back to JPY, so a zero JPY
+	// balance is expected and the cap does not apply.
+	if signal.Action == strategy.SignalBuy {
+		if totalBalanceJPY <= 0 {
+			return fmt.Errorf("insufficient JPY balance for BUY order: %f", totalBalanceJPY)
+		}
+		if err := rm.checkTradeAmount(signal, totalBalanceJPY); err != nil {
+			return fmt.Errorf("trade amount validation failed: %w", err)
+		}
 	}
 
 	// Check daily trade limit

--- a/internal/usecase/risk/manager.go
+++ b/internal/usecase/risk/manager.go
@@ -195,8 +195,9 @@ func (rm *Manager) checkTotalLossLimit(ctx context.Context) error {
 		return nil // OK if no data
 	}
 
-	// Check latest total PnL
-	latestMetric := metrics[len(metrics)-1]
+	// GetPerformanceMetrics returns rows ORDER BY date DESC, so metrics[0] is the
+	// most recent entry.  Using metrics[len-1] was a bug that read the oldest record.
+	latestMetric := metrics[0]
 	totalLoss := -latestMetric.TotalPnL // Negative value indicates loss
 
 	if totalLoss <= 0 {

--- a/internal/usecase/risk/manager_test.go
+++ b/internal/usecase/risk/manager_test.go
@@ -335,6 +335,24 @@ func TestCheckRiskManagement(t *testing.T) {
 			metrics:     []domain.PerformanceMetric{},
 			expectError: true,
 		},
+		{
+			// SELL orders must be allowed even when all capital is deployed in
+			// crypto (JPY balance == 0).  Without this, stop-loss SELL orders are
+			// silently blocked and the position cannot be unwound.
+			name: "SELL allowed with zero JPY balance",
+			signal: &strategy.Signal{
+				Action:   strategy.SignalSell,
+				Price:    5000000,
+				Quantity: 0.001,
+			},
+			balances: []domain.Balance{
+				{Currency: "JPY", Available: 0},
+				{Currency: "BTC", Available: 0.001},
+			},
+			trades:      []domain.Trade{{CreatedAt: now.Add(-10 * time.Minute), ExecutedAt: now.Add(-10 * time.Minute)}},
+			metrics:     []domain.PerformanceMetric{{TotalPnL: 0}},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/usecase/risk/manager_test.go
+++ b/internal/usecase/risk/manager_test.go
@@ -49,13 +49,13 @@ func (m *mockTrader) GetOrders(ctx context.Context) ([]*domain.OrderResult, erro
 	return nil, nil
 }
 
-func (m *mockTrader) SetDatabase(db domain.TradingRepository)            {}
+func (m *mockTrader) SetDatabase(db domain.TradingRepository)           {}
 func (m *mockTrader) SetMarketSpecService(svc domain.MarketSpecService) {}
-func (m *mockTrader) SetStrategyName(name string)                        {}
-func (m *mockTrader) SetOnOrderCompleted(fn func(*domain.OrderResult))   {}
-func (m *mockTrader) InvalidateBalanceCache()                            {}
-func (m *mockTrader) UpdateBalanceToDB(ctx context.Context)              {}
-func (m *mockTrader) Shutdown() error                                    { return nil }
+func (m *mockTrader) SetStrategyName(name string)                       {}
+func (m *mockTrader) SetOnOrderCompleted(fn func(*domain.OrderResult))  {}
+func (m *mockTrader) InvalidateBalanceCache()                           {}
+func (m *mockTrader) UpdateBalanceToDB(ctx context.Context)             {}
+func (m *mockTrader) Shutdown() error                                   { return nil }
 
 func TestCheckTradeAmount(t *testing.T) {
 	cfg := ManagerConfig{

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -306,6 +306,8 @@ func strategyParamsToMap(name string, params interface{}) (map[string]interface{
 }
 
 // initDailyTradeCount restores today's trade count into the strategy.
+// Uses InitializeDailyTradeCount (not RecordTrade) so that the cooldown timer
+// is not reset to time.Now() on every restart.
 func initDailyTradeCount(repo *persistence.Repository, strat pkgstrategy.Strategy, log logger.LoggerInterface) {
 	trades, err := repo.GetRecentTrades(200)
 	if err != nil {
@@ -314,13 +316,15 @@ func initDailyTradeCount(repo *persistence.Repository, strat pkgstrategy.Strateg
 	}
 	now := utils.NowInJST()
 	todayY, todayM, todayD := now.Date()
+	count := 0
 	for i := range trades {
 		t := utils.ToJST(trades[i].ExecutedAt)
 		y, m, d := t.Date()
 		if y == todayY && m == todayM && d == todayD {
-			strat.RecordTrade()
+			count++
 		}
 	}
+	strat.InitializeDailyTradeCount(count)
 }
 
 // ── appServiceAdapter ────────────────────────────────────────────────────────

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -335,7 +335,7 @@ func (a *appServiceAdapter) GetBalances(ctx context.Context) ([]domain.Balance, 
 	return a.trader.GetBalance(ctx)
 }
 func (a *appServiceAdapter) GetCurrentStrategy() pkgstrategy.Strategy { return a.strat }
-func (a *appServiceAdapter) IsTradingEnabled() bool                    { return a.tc.IsTradingEnabled() }
+func (a *appServiceAdapter) IsTradingEnabled() bool                   { return a.tc.IsTradingEnabled() }
 func (a *appServiceAdapter) SetTradingEnabled(enabled bool) error {
 	return a.tc.SetTradingEnabled(enabled)
 }

--- a/pkg/strategy/scalping/strategy.go
+++ b/pkg/strategy/scalping/strategy.go
@@ -339,15 +339,18 @@ func (s *Strategy) calculateEMA(history []strategy.MarketData, period int) float
 	if len(history) < period {
 		return 0.0
 	}
-	data := history[len(history)-period:]
+	// Initialise with SMA of the first period points, then apply the EMA
+	// formula to every subsequent point.  Using the full history avoids the
+	// previous bug where SMA and EMA loop operated on the same slice,
+	// effectively double-counting the most-recent prices.
 	sum := 0.0
-	for i := range data {
-		sum += data[i].Price
+	for i := 0; i < period; i++ {
+		sum += history[i].Price
 	}
 	ema := sum / float64(period)
 	multiplier := 2.0 / float64(period+1)
-	for i := 1; i < len(data); i++ {
-		ema = (data[i].Price-ema)*multiplier + ema
+	for i := period; i < len(history); i++ {
+		ema = (history[i].Price-ema)*multiplier + ema
 	}
 	return ema
 }

--- a/pkg/strategy/scalping/strategy_test.go
+++ b/pkg/strategy/scalping/strategy_test.go
@@ -91,7 +91,7 @@ func TestCalculateEMA_FastSlowOrdering(t *testing.T) {
 // ── GenerateSignal ────────────────────────────────────────────────────────────
 
 func TestGenerateSignal_InsufficientHistory(t *testing.T) {
-	s := newTestStrategy() // slow period = 5
+	s := newTestStrategy()             // slow period = 5
 	hist := makeHistory(100, 100, 100) // only 3 < 5
 	data := &strategy.MarketData{Symbol: "BTC_JPY", Price: 100}
 	sig, err := s.GenerateSignal(context.Background(), data, hist)

--- a/pkg/strategy/scalping/strategy_test.go
+++ b/pkg/strategy/scalping/strategy_test.go
@@ -372,6 +372,22 @@ func TestInitializeDailyTradeCount(t *testing.T) {
 	}
 }
 
+// TestInitializeDailyTradeCount_DoesNotTriggerCooldown verifies that
+// InitializeDailyTradeCount does NOT set lastTradeTime, so the cooldown
+// timer is not activated on startup (regression: engine used RecordTrade
+// which set lastTradeTime = time.Now(), blocking all trades for cooldownSec
+// seconds after every restart).
+func TestInitializeDailyTradeCount_DoesNotTriggerCooldown(t *testing.T) {
+	s := newTestStrategy()
+	s.InitializeDailyTradeCount(3)
+	s.mu.RLock()
+	last := s.lastTradeTime
+	s.mu.RUnlock()
+	if !last.IsZero() {
+		t.Errorf("InitializeDailyTradeCount must not set lastTradeTime (cooldown side-effect), got %v", last)
+	}
+}
+
 // ── Analyze ───────────────────────────────────────────────────────────────────
 
 func TestAnalyze_EmptyData(t *testing.T) {

--- a/pkg/strategy/scalping/strategy_test.go
+++ b/pkg/strategy/scalping/strategy_test.go
@@ -1,0 +1,422 @@
+package scalping
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	strategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+// makeHistory returns a slice of MarketData with given prices, all for "BTC_JPY".
+func makeHistory(prices ...float64) []strategy.MarketData {
+	out := make([]strategy.MarketData, len(prices))
+	for i, p := range prices {
+		out[i] = strategy.MarketData{Symbol: "BTC_JPY", Price: p}
+	}
+	return out
+}
+
+// newTestStrategy creates a Strategy suitable for unit tests (no cooldown / no daily limit).
+func newTestStrategy() *Strategy {
+	return New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    0,
+		MaxDailyTrades: 1000,
+		MinNotional:    100.0,
+		FeeRate:        0.001,
+	})
+}
+
+// ── calculateEMA ─────────────────────────────────────────────────────────────
+
+func TestCalculateEMA_InsufficientHistory(t *testing.T) {
+	s := newTestStrategy()
+	// period=3, only 2 data points → should return 0
+	hist := makeHistory(100, 110)
+	if got := s.calculateEMA(hist, 3); got != 0.0 {
+		t.Errorf("expected 0.0 for insufficient history, got %v", got)
+	}
+}
+
+func TestCalculateEMA_ExactPeriod(t *testing.T) {
+	s := newTestStrategy()
+	// With exactly 3 equal prices the EMA equals that price.
+	hist := makeHistory(100, 100, 100)
+	if got := s.calculateEMA(hist, 3); got != 100.0 {
+		t.Errorf("expected 100.0, got %v", got)
+	}
+}
+
+func TestCalculateEMA_FullWarmup(t *testing.T) {
+	// Verify the fixed algorithm: SMA from first `period` points, then EMA loop
+	// over remaining points.  A constant series must always return that constant.
+	s := newTestStrategy()
+	hist := makeHistory(200, 200, 200, 200, 200, 200, 200)
+	for _, period := range []int{3, 5, 7} {
+		if got := s.calculateEMA(hist, period); got != 200.0 {
+			t.Errorf("period=%d: expected 200.0, got %v", period, got)
+		}
+	}
+}
+
+func TestCalculateEMA_RisingPrices(t *testing.T) {
+	// For a steadily rising series the EMA must be below the last price (lag).
+	s := newTestStrategy()
+	hist := makeHistory(100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120)
+	ema := s.calculateEMA(hist, 5)
+	last := hist[len(hist)-1].Price
+	if ema >= last {
+		t.Errorf("expected EMA (%v) < last price (%v) for rising series", ema, last)
+	}
+	if ema <= 100 {
+		t.Errorf("expected EMA (%v) > first price for rising series", ema)
+	}
+}
+
+func TestCalculateEMA_FastSlowOrdering(t *testing.T) {
+	// In a rising trend, faster EMA must be higher than slower EMA.
+	s := newTestStrategy()
+	hist := makeHistory(100, 101, 103, 106, 110, 115, 121, 128, 136, 145, 155)
+	emaFast := s.calculateEMA(hist, 3)
+	emaSlow := s.calculateEMA(hist, 5)
+	if emaFast <= emaSlow {
+		t.Errorf("expected fast EMA (%v) > slow EMA (%v) in rising trend", emaFast, emaSlow)
+	}
+}
+
+// ── GenerateSignal ────────────────────────────────────────────────────────────
+
+func TestGenerateSignal_InsufficientHistory(t *testing.T) {
+	s := newTestStrategy() // slow period = 5
+	hist := makeHistory(100, 100, 100) // only 3 < 5
+	data := &strategy.MarketData{Symbol: "BTC_JPY", Price: 100}
+	sig, err := s.GenerateSignal(context.Background(), data, hist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig.Action != strategy.SignalHold {
+		t.Errorf("expected HOLD for insufficient history, got %v", sig.Action)
+	}
+}
+
+func TestGenerateSignal_NilData(t *testing.T) {
+	s := newTestStrategy()
+	_, err := s.GenerateSignal(context.Background(), nil, makeHistory(100, 100, 100, 100, 100))
+	if err == nil {
+		t.Error("expected error for nil market data")
+	}
+}
+
+func buildBuyHistory() []strategy.MarketData {
+	// Build a history where fast EMA (3) > slow EMA (5) and price > fast EMA.
+	// Use a strongly rising series.
+	return makeHistory(100, 100, 100, 100, 100, 110, 120, 130, 140, 150)
+}
+
+func TestGenerateSignal_BuyOnCrossover(t *testing.T) {
+	s := newTestStrategy()
+	hist := buildBuyHistory()
+	data := &strategy.MarketData{Symbol: "BTC_JPY", Price: hist[len(hist)-1].Price}
+
+	// First call — crossover should be detected (initialized=false).
+	sig, err := s.GenerateSignal(context.Background(), data, hist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig.Action != strategy.SignalBuy {
+		t.Logf("signal=%v metadata=%v", sig.Action, sig.Metadata)
+		t.Errorf("expected BUY on first crossover, got %v", sig.Action)
+	}
+}
+
+func TestGenerateSignal_HoldOnRepeatDirection(t *testing.T) {
+	s := newTestStrategy()
+	hist := buildBuyHistory()
+	data := &strategy.MarketData{Symbol: "BTC_JPY", Price: hist[len(hist)-1].Price}
+
+	// First call initialises the EMA state.
+	s.GenerateSignal(context.Background(), data, hist) //nolint:errcheck
+
+	// Second call with same rising history — no new crossover → HOLD.
+	sig, err := s.GenerateSignal(context.Background(), data, hist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig.Action != strategy.SignalHold {
+		t.Errorf("expected HOLD on repeated direction (no new crossover), got %v", sig.Action)
+	}
+}
+
+// ── Cooldown ─────────────────────────────────────────────────────────────────
+
+func TestIsInCooldown_NoTrade(t *testing.T) {
+	s := newTestStrategy()
+	if s.isInCooldown() {
+		t.Error("expected no cooldown before any trade")
+	}
+}
+
+func TestIsInCooldown_AfterTrade(t *testing.T) {
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    3600,
+		MaxDailyTrades: 1000,
+		MinNotional:    100.0,
+		FeeRate:        0.001,
+	})
+	s.RecordTrade()
+	if !s.isInCooldown() {
+		t.Error("expected cooldown immediately after RecordTrade")
+	}
+}
+
+// ── Daily limit ───────────────────────────────────────────────────────────────
+
+func TestIsDailyLimitReached_BelowLimit(t *testing.T) {
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    0,
+		MaxDailyTrades: 3,
+		MinNotional:    100.0,
+		FeeRate:        0.001,
+	})
+	s.RecordTrade()
+	s.RecordTrade()
+	if s.isDailyLimitReached() {
+		t.Error("expected limit NOT reached after 2/3 trades")
+	}
+}
+
+func TestIsDailyLimitReached_AtLimit(t *testing.T) {
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    0,
+		MaxDailyTrades: 3,
+		MinNotional:    100.0,
+		FeeRate:        0.001,
+	})
+	s.RecordTrade()
+	s.RecordTrade()
+	s.RecordTrade()
+	if !s.isDailyLimitReached() {
+		t.Error("expected limit reached after 3/3 trades")
+	}
+}
+
+// ── RecordTrade / Reset ───────────────────────────────────────────────────────
+
+func TestRecordTrade_IncrementsCount(t *testing.T) {
+	s := newTestStrategy()
+	for i := 0; i < 5; i++ {
+		s.RecordTrade()
+	}
+	s.mu.RLock()
+	count := s.dailyTradeCount
+	s.mu.RUnlock()
+	if count != 5 {
+		t.Errorf("expected dailyTradeCount=5, got %d", count)
+	}
+}
+
+func TestReset_ClearsState(t *testing.T) {
+	s := newTestStrategy()
+	s.RecordTrade()
+	if err := s.Reset(); err != nil {
+		t.Fatalf("Reset returned error: %v", err)
+	}
+	s.mu.RLock()
+	count := s.dailyTradeCount
+	s.mu.RUnlock()
+	if count != 0 {
+		t.Errorf("expected dailyTradeCount=0 after Reset, got %d", count)
+	}
+	if s.isInCooldown() {
+		t.Error("expected no cooldown after Reset")
+	}
+}
+
+// ── Take-profit / Stop-loss prices ───────────────────────────────────────────
+
+func TestGetTakeProfitPrice(t *testing.T) {
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TakeProfitPct:  2.0,
+		StopLossPct:    1.0,
+		CooldownSec:    0,
+		MaxDailyTrades: 10,
+		MinNotional:    100.0,
+		FeeRate:        0.001,
+	})
+	got := s.GetTakeProfitPrice(1000.0)
+	want := 1020.0
+	if got != want {
+		t.Errorf("GetTakeProfitPrice(1000) = %v, want %v", got, want)
+	}
+}
+
+func TestGetStopLossPrice(t *testing.T) {
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TakeProfitPct:  2.0,
+		StopLossPct:    1.0,
+		CooldownSec:    0,
+		MaxDailyTrades: 10,
+		MinNotional:    100.0,
+		FeeRate:        0.001,
+	})
+	got := s.GetStopLossPrice(1000.0)
+	want := 990.0
+	if got != want {
+		t.Errorf("GetStopLossPrice(1000) = %v, want %v", got, want)
+	}
+}
+
+// ── Initialize / validate ─────────────────────────────────────────────────────
+
+func TestInitialize_ValidParams(t *testing.T) {
+	s := newTestStrategy()
+	err := s.Initialize(map[string]interface{}{
+		"ema_fast_period":  5,
+		"ema_slow_period":  10,
+		"take_profit_pct":  1.5,
+		"stop_loss_pct":    0.8,
+		"cooldown_sec":     60,
+		"max_daily_trades": 5,
+		"min_notional":     500.0,
+		"fee_rate":         0.001,
+	})
+	if err != nil {
+		t.Errorf("unexpected validate error: %v", err)
+	}
+}
+
+func TestInitialize_FastPeriodGTSlow(t *testing.T) {
+	s := newTestStrategy()
+	err := s.Initialize(map[string]interface{}{
+		"ema_fast_period":  10,
+		"ema_slow_period":  5, // invalid: fast >= slow
+		"take_profit_pct":  1.0,
+		"stop_loss_pct":    0.5,
+		"cooldown_sec":     0,
+		"max_daily_trades": 10,
+		"min_notional":     100.0,
+		"fee_rate":         0.001,
+	})
+	if err == nil {
+		t.Error("expected error when ema_fast_period >= ema_slow_period")
+	}
+}
+
+// ── RSI filter ────────────────────────────────────────────────────────────────
+
+func TestGenerateSignal_RSIOverboughtBlocksBuy(t *testing.T) {
+	// RSI with overbought=40 (very low threshold) should block BUY on a rising series.
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    0,
+		MaxDailyTrades: 1000,
+		MinNotional:    100.0,
+		FeeRate:        0.001,
+		RSIPeriod:      3,
+		RSIOverbought:  40.0, // very low — forces RSI>40 on a rising series
+		RSIOversold:    10.0,
+	})
+
+	// Strongly rising prices → RSI will be > 40.
+	hist := makeHistory(100, 100, 100, 100, 100, 110, 120, 130, 140, 200)
+	data := &strategy.MarketData{Symbol: "BTC_JPY", Price: 200}
+	sig, err := s.GenerateSignal(context.Background(), data, hist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Either HOLD (RSI filtered) or BUY depending on exact RSI value.
+	// The important thing is no error and action is a valid value.
+	if sig.Action != strategy.SignalHold && sig.Action != strategy.SignalBuy {
+		t.Errorf("unexpected action %v", sig.Action)
+	}
+}
+
+// ── InitializeDailyTradeCount ─────────────────────────────────────────────────
+
+func TestInitializeDailyTradeCount(t *testing.T) {
+	s := newTestStrategy()
+	s.InitializeDailyTradeCount(7)
+	s.mu.RLock()
+	count := s.dailyTradeCount
+	date := s.lastTradeDate
+	s.mu.RUnlock()
+	if count != 7 {
+		t.Errorf("expected dailyTradeCount=7, got %d", count)
+	}
+	today := time.Now().Format("2006-01-02")
+	if date != today {
+		t.Errorf("expected lastTradeDate=%s, got %s", today, date)
+	}
+}
+
+// ── Analyze ───────────────────────────────────────────────────────────────────
+
+func TestAnalyze_EmptyData(t *testing.T) {
+	s := newTestStrategy()
+	_, err := s.Analyze(nil)
+	if err == nil {
+		t.Error("expected error for empty data in Analyze")
+	}
+}
+
+func TestAnalyze_DelegatesCorrectly(t *testing.T) {
+	s := newTestStrategy()
+	hist := buildBuyHistory()
+	sig, err := s.Analyze(hist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig == nil {
+		t.Fatal("expected non-nil signal from Analyze")
+	}
+}
+
+// ── SymbolOverride ────────────────────────────────────────────────────────────
+
+func TestSymbolEMAPeriods_Override(t *testing.T) {
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    0,
+		MaxDailyTrades: 10,
+		MinNotional:    100.0,
+		FeeRate:        0.001,
+		SymbolParams: map[string]SymbolOverride{
+			"ETH_JPY": {EMAFastPeriod: 7, EMASlowPeriod: 21},
+		},
+	})
+	fast, slow := s.symbolEMAPeriods("ETH_JPY")
+	if fast != 7 || slow != 21 {
+		t.Errorf("expected fast=7 slow=21 for ETH_JPY override, got fast=%d slow=%d", fast, slow)
+	}
+	// For non-overridden symbol, global defaults should apply.
+	fast, slow = s.symbolEMAPeriods("BTC_JPY")
+	if fast != 3 || slow != 5 {
+		t.Errorf("expected fast=3 slow=5 for BTC_JPY (global default), got fast=%d slow=%d", fast, slow)
+	}
+}

--- a/web/index.html
+++ b/web/index.html
@@ -192,6 +192,31 @@
                   </table>
                 </div>
               </div>
+              <!-- リスク指標 -->
+              <div class="card flex flex-col">
+                <div class="card-header">
+                  <h2 class="text-base font-semibold">リスク指標</h2>
+                </div>
+                <div class="card-body">
+                  <div class="grid grid-cols-3 gap-4">
+                    <div>
+                      <p class="text-xs text-secondary mb-1">シャープレシオ</p>
+                      <p id="sharpe-ratio" class="text-2xl font-bold">-</p>
+                      <span class="text-xs text-secondary">目安: &gt;1.0</span>
+                    </div>
+                    <div>
+                      <p class="text-xs text-secondary mb-1">プロフィットファクター</p>
+                      <p id="profit-factor" class="text-2xl font-bold">-</p>
+                      <span class="text-xs text-secondary">目安: &gt;1.5</span>
+                    </div>
+                    <div>
+                      <p class="text-xs text-secondary mb-1">最大ドローダウン</p>
+                      <p id="max-drawdown" class="text-2xl font-bold">-</p>
+                      <span class="text-xs text-secondary">小さいほど良い</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
               <!-- 日別損益 -->
               <div class="card flex flex-col">
                 <div class="card-header">

--- a/web/index.html
+++ b/web/index.html
@@ -315,7 +315,6 @@
     </div>
     <!-- /dashboard -->
 
-    <script src="script.js?v=20260318"></script>
+    <script src="script.js?v=20260319"></script>
   </body>
-</html>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -75,14 +75,14 @@
         <!-- Content -->
         <div class="dashboard-content">
 
-          <!-- ── Page: ダッシュボード ── -->
+          <!-- ── Page: Dashboard ── -->
           <div id="page-dashboard" class="page-section">
             <div class="mb-6">
               <h1 class="text-2xl font-bold">ダッシュボード</h1>
             </div>
             <!-- Stat Cards -->
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-              <!-- 総損益 -->
+              <!-- Total P&L -->
               <div class="card stat-card">
                 <div class="card-body p-4">
                   <div class="flex items-center justify-between mb-3">
@@ -95,7 +95,7 @@
                   <span class="text-xs text-secondary">累計</span>
                 </div>
               </div>
-              <!-- 本日損益 -->
+              <!-- Today's P&L -->
               <div class="card stat-card">
                 <div class="card-body p-4">
                   <div class="flex items-center justify-between mb-3">
@@ -108,7 +108,7 @@
                   <span class="text-xs text-secondary">本日</span>
                 </div>
               </div>
-              <!-- 勝率 -->
+              <!-- Win Rate -->
               <div class="card stat-card">
                 <div class="card-body p-4">
                   <div class="flex items-center justify-between mb-3">
@@ -121,7 +121,7 @@
                   <span class="text-xs text-secondary">勝率</span>
                 </div>
               </div>
-              <!-- 総取引回数 -->
+              <!-- Total Trades -->
               <div class="card stat-card">
                 <div class="card-body p-4">
                   <div class="flex items-center justify-between mb-3">
@@ -166,13 +166,13 @@
           </div>
           <!-- /page-dashboard -->
 
-          <!-- ── Page: パフォーマンス ── -->
+          <!-- ── Page: Performance ── -->
           <div id="page-performance" class="page-section hidden">
             <div class="mb-6">
               <h1 class="text-2xl font-bold">パフォーマンス</h1>
             </div>
             <div class="grid md:grid-cols-2 gap-4">
-              <!-- 残高 -->
+              <!-- Balance -->
               <div class="card flex flex-col">
                 <div class="card-header">
                   <h2 class="text-base font-semibold">残高</h2>
@@ -192,7 +192,7 @@
                   </table>
                 </div>
               </div>
-              <!-- リスク指標 -->
+              <!-- Risk Metrics -->
               <div class="card flex flex-col">
                 <div class="card-header">
                   <h2 class="text-base font-semibold">リスク指標</h2>
@@ -217,7 +217,7 @@
                   </div>
                 </div>
               </div>
-              <!-- 日別損益 -->
+              <!-- Daily P&L -->
               <div class="card flex flex-col">
                 <div class="card-header">
                   <h2 class="text-base font-semibold">日別損益</h2>
@@ -242,7 +242,7 @@
           </div>
           <!-- /page-performance -->
 
-          <!-- ── Page: 取引履歴 ── -->
+          <!-- ── Page: Trade History ── -->
           <div id="page-trades" class="page-section hidden">
             <div class="mb-6">
               <h1 class="text-2xl font-bold">取引履歴</h1>
@@ -270,7 +270,7 @@
           </div>
           <!-- /page-trades -->
 
-          <!-- ── Page: システムログ ── -->
+          <!-- ── Page: System Logs ── -->
           <div id="page-logs" class="page-section hidden">
             <div class="mb-6">
               <h1 class="text-2xl font-bold">システムログ</h1>

--- a/web/script.js
+++ b/web/script.js
@@ -304,11 +304,17 @@ class GogocoinUI {
         const totalPnlEl = document.getElementById('total-pnl');
         const winRateEl = document.getElementById('win-rate');
         const todayPnlEl = document.getElementById('today-pnl');
+        const sharpeEl = document.getElementById('sharpe-ratio');
+        const profitFactorEl = document.getElementById('profit-factor');
+        const maxDrawdownEl = document.getElementById('max-drawdown');
 
         if (hasError) {
             if (totalPnlEl) { totalPnlEl.textContent = '取得エラー'; totalPnlEl.className = 'text-xl font-bold text-danger'; }
             if (winRateEl) { winRateEl.textContent = '-'; winRateEl.className = 'text-lg font-bold text-secondary'; }
             if (todayPnlEl) { todayPnlEl.textContent = '-'; todayPnlEl.className = 'text-lg font-bold text-secondary'; }
+            if (sharpeEl) { sharpeEl.textContent = '-'; }
+            if (profitFactorEl) { profitFactorEl.textContent = '-'; }
+            if (maxDrawdownEl) { maxDrawdownEl.textContent = '-'; }
             return;
         }
 
@@ -326,6 +332,9 @@ class GogocoinUI {
                 todayPnlEl.textContent = '¥0';
                 todayPnlEl.className = 'text-2xl font-black';
             }
+            if (sharpeEl) { sharpeEl.textContent = '-'; }
+            if (profitFactorEl) { profitFactorEl.textContent = '-'; }
+            if (maxDrawdownEl) { maxDrawdownEl.textContent = '-'; }
             return;
         }
 
@@ -339,6 +348,21 @@ class GogocoinUI {
         if (winRateEl) {
             winRateEl.textContent = this.formatPercent(latest.win_rate);
             winRateEl.className = 'text-lg font-bold';
+        }
+        if (sharpeEl) {
+            const v = latest.sharpe_ratio;
+            sharpeEl.textContent = (v != null && !isNaN(v)) ? parseFloat(v).toFixed(2) : '-';
+            sharpeEl.className = 'text-2xl font-bold' + (v >= 1.0 ? ' text-success' : v != null ? ' text-danger' : '');
+        }
+        if (profitFactorEl) {
+            const v = latest.profit_factor;
+            profitFactorEl.textContent = (v != null && !isNaN(v)) ? parseFloat(v).toFixed(2) : '-';
+            profitFactorEl.className = 'text-2xl font-bold' + (v >= 1.5 ? ' text-success' : v != null ? ' text-danger' : '');
+        }
+        if (maxDrawdownEl) {
+            const v = latest.max_drawdown;
+            maxDrawdownEl.textContent = (v != null && !isNaN(v)) ? parseFloat(v).toFixed(2) + '%' : '-';
+            maxDrawdownEl.className = 'text-2xl font-bold' + (v != null && v <= 10 ? ' text-success' : v != null ? ' text-danger' : '');
         }
 
         // Calculate today's PnL from actual trade records (JST date match)

--- a/web/script.js
+++ b/web/script.js
@@ -90,7 +90,7 @@ class GogocoinUI {
             this.updateInterval = setTimeout(async () => {
                 try {
                     await this.loadDashboardData();
-                    // ログも更新
+                    // Also refresh logs
                     this.loadLogs().catch(err => {
                         console.error('Failed to load logs:', err);
                     });
@@ -112,7 +112,7 @@ class GogocoinUI {
     async loadInitialData() {
         try {
             await this.loadDashboardData();
-            // ダッシュボードにもログが表示されるので初期ロード
+            // Dashboard also shows logs, so load on init
             this.loadLogs().catch(err => {
                 console.error('Failed to load initial logs:', err);
             });
@@ -442,7 +442,7 @@ class GogocoinUI {
                 url += `&category=${category}`;
             }
 
-            // 30秒タイムアウト（ログAPIが遅い可能性がある）
+            // 30s timeout (log API may be slow)
             const logs = await this.fetchAPI(url, 'GET', null, 30000);
 
             const container = document.getElementById('logs-container');
@@ -550,13 +550,13 @@ class GogocoinUI {
         return div.innerHTML;
     }
 
-    // Format number用のヘルパーメソッド
+    // Format number helper
     formatNumber(value) {
         if (value === null || value === undefined) return '-';
         const num = parseFloat(value);
         if (isNaN(num)) return '-';
 
-        // -0を0に変換
+        // Convert -0 to 0
         if (num === 0) return '0';
 
         return new Intl.NumberFormat('ja-JP', {
@@ -565,16 +565,16 @@ class GogocoinUI {
         }).format(num);
     }
 
-    // Format currency用のヘルパーメソッド
+    // Format currency helper
     formatCurrency(value) {
         if (value === null || value === undefined) return '¥0';
         const num = parseFloat(value);
         if (isNaN(num)) return '¥0';
 
-        // -0を0に変換
+        // Convert -0 to 0
         if (num === 0) return '¥0';
 
-        // 市場価格やトレード価格の精度を保つため、小数点以下2桁まで表示
+        // Show up to 2 decimal places for market/trade price precision
         return new Intl.NumberFormat('ja-JP', {
             style: 'currency',
             currency: 'JPY',
@@ -583,16 +583,16 @@ class GogocoinUI {
         }).format(num);
     }
 
-    // Format fee (手数料) 用のヘルパーメソッド - 小数点以下も表示
+    // Format fee helper - show decimal places
     formatFee(value) {
         if (value === null || value === undefined) return '-';
         const num = parseFloat(value);
         if (isNaN(num)) return '-';
 
-        // -0を0に変換
+        // Convert -0 to 0
         if (num === 0) return '-';
 
-        // 小数点以下8桁まで表示（暗号通貨の精度に対応）
+        // Show up to 8 decimal places (for crypto precision)
         return new Intl.NumberFormat('ja-JP', {
             minimumFractionDigits: 0,
             maximumFractionDigits: 8
@@ -611,7 +611,7 @@ class GogocoinUI {
         });
     }
 
-    // Format date用のヘルパーメソッド
+    // Format date helper
     formatDate(dateString) {
         if (!dateString) return '-';
         const date = new Date(dateString);
@@ -622,7 +622,7 @@ class GogocoinUI {
         });
     }
 
-    // Format datetime用のヘルパーメソッド
+    // Format datetime helper
     formatDateTime(dateString) {
         if (!dateString) return '-';
         const date = new Date(dateString);
@@ -647,13 +647,13 @@ class GogocoinUI {
         });
     }
 
-    // Format percentage用のヘルパーメソッド
+    // Format percentage helper
     formatPercent(value) {
         if (value === null || value === undefined) return '-';
         const num = parseFloat(value);
         if (isNaN(num)) return '-';
 
-        // -0を0に変換
+        // Convert -0 to 0
         if (num === 0) return '0%';
 
         return new Intl.NumberFormat('ja-JP', {
@@ -663,7 +663,7 @@ class GogocoinUI {
         }).format(num / 100);
     }
 
-    // API呼び出し用のヘルパーメソッド
+    // API call helper
     async fetchAPI(url, method = 'GET', body = null, timeout = 10000) {
         try {
             const controller = new AbortController();
@@ -707,7 +707,7 @@ class GogocoinUI {
 
         if (!startBtn || !stopBtn) return;
 
-        // ボタンを無効化してローディング表示
+        // Disable button and show loading
         startBtn.disabled = true;
         startBtn.textContent = '開始中...';
 
@@ -715,17 +715,17 @@ class GogocoinUI {
             const response = await this.fetchAPI('/api/trading/start', 'POST', null, 10000);
             console.log('Start trading response:', response);
 
-            // 成功 - サーバーからの最新状態を取得してボタンを更新
+            // Success - fetch latest state from server and update buttons
             try {
                 await this.loadDashboardData();
             } catch (dashboardError) {
-                // ダッシュボードデータ取得失敗でも、最低限statusだけは取得
+                // Dashboard load failed; try to at least fetch status
                 console.error('Dashboard load failed, fetching status only:', dashboardError);
                 try {
                     const status = await this.fetchAPI(`/api/status?symbol=${this.selectedSymbol}`);
                     this.updateSystemStatus(status);
                 } catch (statusError) {
-                    // ダッシュボード更新失敗は取引開始の成否とは無関係。ログにとどめる。
+                    // Dashboard update failure is unrelated to trading start result. Log only.
                     console.error('Status fetch also failed (trading was started successfully):', statusError);
                 }
             }
@@ -733,7 +733,7 @@ class GogocoinUI {
             console.error('Error starting trading:', error);
             alert('取引開始に失敗しました: ' + error.message);
 
-            // エラー時はボタンを元に戻す
+            // Restore button on error
             startBtn.disabled = false;
             startBtn.textContent = '開始';
         }
@@ -746,7 +746,7 @@ class GogocoinUI {
 
         if (!startBtn || !stopBtn) return;
 
-        // ボタンを無効化してローディング表示
+        // Disable button and show loading
         stopBtn.disabled = true;
         stopBtn.textContent = '停止中...';
 
@@ -754,17 +754,17 @@ class GogocoinUI {
             const response = await this.fetchAPI('/api/trading/stop', 'POST', null, 10000);
             console.log('Stop trading response:', response);
 
-            // 成功 - サーバーからの最新状態を取得してボタンを更新
+            // Success - fetch latest state from server and update buttons
             try {
                 await this.loadDashboardData();
             } catch (dashboardError) {
-                // ダッシュボードデータ取得失敗でも、最低限statusだけは取得
+                // Dashboard load failed; try to at least fetch status
                 console.error('Dashboard load failed, fetching status only:', dashboardError);
                 try {
                     const status = await this.fetchAPI(`/api/status?symbol=${this.selectedSymbol}`);
                     this.updateSystemStatus(status);
                 } catch (statusError) {
-                    // ダッシュボード更新失敗は取引停止の成否とは無関係。ログにとどめる。
+                    // Dashboard update failure is unrelated to trading stop result. Log only.
                     console.error('Status fetch also failed (trading was stopped successfully):', statusError);
                 }
             }
@@ -772,7 +772,7 @@ class GogocoinUI {
             console.error('Error stopping trading:', error);
             alert('取引停止に失敗しました: ' + error.message);
 
-            // エラー時はボタンを元に戻す
+            // Restore button on error
             stopBtn.disabled = false;
             stopBtn.textContent = '停止';
         }
@@ -780,7 +780,7 @@ class GogocoinUI {
 
 }
 
-// アプリケーション初期化
+// Initialize application
 document.addEventListener('DOMContentLoaded', () => {
     new GogocoinUI();
 });

--- a/web/script.js
+++ b/web/script.js
@@ -351,18 +351,21 @@ class GogocoinUI {
         }
         if (sharpeEl) {
             const v = latest.sharpe_ratio;
-            sharpeEl.textContent = (v != null && !isNaN(v)) ? parseFloat(v).toFixed(2) : '-';
-            sharpeEl.className = 'text-2xl font-bold' + (v >= 1.0 ? ' text-success' : v != null ? ' text-danger' : '');
+            const vValid = v != null && !isNaN(v);
+            sharpeEl.textContent = vValid ? parseFloat(v).toFixed(2) : '-';
+            sharpeEl.className = 'text-2xl font-bold' + (vValid ? (v >= 1.0 ? ' text-success' : ' text-danger') : '');
         }
         if (profitFactorEl) {
             const v = latest.profit_factor;
-            profitFactorEl.textContent = (v != null && !isNaN(v)) ? parseFloat(v).toFixed(2) : '-';
-            profitFactorEl.className = 'text-2xl font-bold' + (v >= 1.5 ? ' text-success' : v != null ? ' text-danger' : '');
+            const vValid = v != null && !isNaN(v);
+            profitFactorEl.textContent = vValid ? parseFloat(v).toFixed(2) : '-';
+            profitFactorEl.className = 'text-2xl font-bold' + (vValid ? (v >= 1.5 ? ' text-success' : ' text-danger') : '');
         }
         if (maxDrawdownEl) {
             const v = latest.max_drawdown;
-            maxDrawdownEl.textContent = (v != null && !isNaN(v)) ? parseFloat(v).toFixed(2) + '%' : '-';
-            maxDrawdownEl.className = 'text-2xl font-bold' + (v != null && v <= 10 ? ' text-success' : v != null ? ' text-danger' : '');
+            const vValid = v != null && !isNaN(v);
+            maxDrawdownEl.textContent = vValid ? parseFloat(v).toFixed(2) + '%' : '-';
+            maxDrawdownEl.className = 'text-2xl font-bold' + (vValid ? (v <= 10 ? ' text-success' : ' text-danger') : '');
         }
 
         // Calculate today's PnL from actual trade records (JST date match)
@@ -454,8 +457,8 @@ class GogocoinUI {
                 return;
             }
 
-            // Reverse to show newest first
-            const reversedLogs = logs.reverse();
+            // Reverse to show newest first (slice to avoid mutating original)
+            const reversedLogs = logs.slice().reverse();
 
             container.innerHTML = reversedLogs.map(log => {
                 const levelClass = log.level.toLowerCase();
@@ -757,8 +760,13 @@ class GogocoinUI {
             } catch (dashboardError) {
                 // ダッシュボードデータ取得失敗でも、最低限statusだけは取得
                 console.error('Dashboard load failed, fetching status only:', dashboardError);
-                const status = await this.fetchAPI(`/api/status?symbol=${this.selectedSymbol}`);
-                this.updateSystemStatus(status);
+                try {
+                    const status = await this.fetchAPI(`/api/status?symbol=${this.selectedSymbol}`);
+                    this.updateSystemStatus(status);
+                } catch (statusError) {
+                    // ダッシュボード更新失敗は取引停止の成否とは無関係。ログにとどめる。
+                    console.error('Status fetch also failed (trading was stopped successfully):', statusError);
+                }
             }
         } catch (error) {
             console.error('Error stopping trading:', error);


### PR DESCRIPTION
## Summary

Add risk metrics display to the Performance page, plus fix multiple bugs discovered during thorough code review.

---

## Changes

### feat: Web UI — Risk Metrics (`web/index.html`, `web/script.js`)

- Add "Risk Metrics" card to Performance page (Sharpe Ratio / Profit Factor / Max Drawdown)
- Color-coded thresholds (green when Sharpe > 1.0, PF > 1.5)

### fix: 4 Web UI bugs (`web/script.js`, `web/index.html`)

- `stopTrading()` inner catch was swallowing the outer error handler
- NaN values were not getting the correct color class
- `logs.reverse()` was mutating the master array in-place
- Duplicate `</html>` tag

### fix: `calculateEMA` double-counting (`pkg/strategy/scalping/strategy.go`)

- SMA calculation slice was reused by the EMA loop, causing initial values to be double-counted
- Fix: SMA uses `history[0:period]`, EMA loop uses `history[period:]`

### fix: `checkTotalLossLimit` reads oldest metric (`internal/usecase/risk/manager.go`)

- `GetPerformanceMetrics` returns `ORDER BY date DESC`, so `metrics[0]` is the latest
- Was reading `metrics[len(metrics)-1]` (30 days ago), causing incorrect loss rate evaluation

### fix: SELL orders silently blocked when JPY balance is zero [CRITICAL] (`internal/usecase/risk/manager.go`)

- `CheckRiskManagement` applied JPY balance guard and `checkTradeAmount` to ALL signals
- When all capital is held in BTC (JPY=0), stop-loss SELL orders were silently rejected
- Fix: scope both checks to BUY signals only

### fix: `totalAssets` zero-division (`internal/usecase/risk/manager.go`)

- When balance fetch fails, `totalAssets=0` causes loss rate to be +Inf, triggering false loss limit
- Fix: use `InitialBalance` as fallback

### fix: `RateLimiter.Stop()` double-close panic (`internal/infra/exchange/bitflyer/client.go`)

- Calling `Stop()` multiple times caused a channel double-close panic
- Fix: wrap with `sync.Once`

### fix: `initDailyTradeCount` triggers cooldown on restart (`pkg/engine/engine.go`)

- Loop-calling `strat.RecordTrade()` sets `lastTradeTime = time.Now()` on each call
- After restart, all trades were blocked for `cooldownSec` seconds
- Fix: count today's trades once and call `InitializeDailyTradeCount(count)`

### test: Scalping strategy tests (`pkg/strategy/scalping/strategy_test.go`)

- 25 test cases covering EMA warmup/ordering, signal generation, cooldown, RSI, daily limits, and regression tests

---

## Test Results

```
ok  github.com/bmf-san/gogocoin/internal/adapter/http
ok  github.com/bmf-san/gogocoin/internal/adapter/worker
ok  github.com/bmf-san/gogocoin/internal/config
ok  github.com/bmf-san/gogocoin/internal/infra/exchange/bitflyer
ok  github.com/bmf-san/gogocoin/internal/infra/persistence
ok  github.com/bmf-san/gogocoin/internal/integration
ok  github.com/bmf-san/gogocoin/internal/logger
ok  github.com/bmf-san/gogocoin/internal/usecase/analytics
ok  github.com/bmf-san/gogocoin/internal/usecase/risk
ok  github.com/bmf-san/gogocoin/internal/usecase/trading/balance
ok  github.com/bmf-san/gogocoin/internal/usecase/trading/monitor
ok  github.com/bmf-san/gogocoin/internal/usecase/trading/order
ok  github.com/bmf-san/gogocoin/internal/usecase/trading/pnl
ok  github.com/bmf-san/gogocoin/internal/usecase/trading/validator
ok  github.com/bmf-san/gogocoin/pkg/strategy/scalping
```