### PR TITLE
feat: show today's trade count instead of cumulative total on dashboard

### DIFF
--- a/internal/adapter/http/contracts.go
+++ b/internal/adapter/http/contracts.go
@@ -18,6 +18,7 @@ type DatabaseService interface {
 	// Trade operations
 	GetRecentTrades(limit int) ([]domain.Trade, error)
 	GetTradesCount() (int, error)
+	GetTodayTradesCount() (int, error)
 
 	// Position operations
 	GetActivePositions() ([]domain.Position, error)

--- a/internal/adapter/http/handler_status.go
+++ b/internal/adapter/http/handler_status.go
@@ -38,9 +38,9 @@ func (s *Server) GetApiStatus(ctx context.Context, request GetApiStatusRequestOb
 
 	uptime := s.calculateUptime()
 
-	totalTrades, err := s.getTotalTradesCount()
+	totalTrades, err := s.getTodayTradesCount()
 	if err != nil {
-		s.logger.Error("Failed to get total trades count: " + err.Error())
+		s.logger.Error("Failed to get today's trades count: " + err.Error())
 		totalTrades = 0
 	}
 

--- a/internal/adapter/http/server.go
+++ b/internal/adapter/http/server.go
@@ -203,6 +203,11 @@ func (s *Server) getTotalTradesCount() (int, error) {
 	return s.db.GetTradesCount()
 }
 
+// getTodayTradesCount gets the number of trades executed today (JST)
+func (s *Server) getTodayTradesCount() (int, error) {
+	return s.db.GetTodayTradesCount()
+}
+
 // isRateLimitError checks if an error is a rate limit error using sentinel errors
 func isRateLimitError(err error) bool {
 	if err == nil {

--- a/internal/infra/persistence/repository.go
+++ b/internal/infra/persistence/repository.go
@@ -46,6 +46,9 @@ func (r *Repository) GetAllTrades() ([]domain.Trade, error) {
 func (r *Repository) GetTradesCount() (int, error) {
 	return r.trade.GetTradesCount()
 }
+func (r *Repository) GetTodayTradesCount() (int, error) {
+	return r.trade.GetTodayTradesCount()
+}
 
 // --- domain.PositionRepository ---
 

--- a/internal/infra/persistence/trade_repo.go
+++ b/internal/infra/persistence/trade_repo.go
@@ -97,3 +97,16 @@ func (r *TradeRepository) GetTradesCount() (int, error) {
 	}
 	return count, nil
 }
+
+// GetTodayTradesCount returns the number of trades executed today (JST).
+func (r *TradeRepository) GetTodayTradesCount() (int, error) {
+	var count int
+	// Use JST (UTC+9) to determine today's date boundary
+	err := r.db.db.QueryRow(
+		"SELECT COUNT(*) FROM trades WHERE executed_at >= datetime('now', '+9 hours', 'start of day', '-9 hours')",
+	).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/web/index.html
+++ b/web/index.html
@@ -131,7 +131,7 @@
                     </svg>
                   </div>
                   <p id="total-trades" class="text-2xl font-bold mb-1">-</p>
-                  <span class="text-xs text-secondary">累計</span>
+                  <span class="text-xs text-secondary">本日</span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary

This change was originally part of PR #30 but was not included in the squash merge. It changes the dashboard trade count from cumulative total to today's count (JST-based).

## Changes

- **`trade_repo.go`**: Add `GetTodayTradesCount()` — counts trades executed since JST 00:00 today using SQLite datetime functions
- **`repository.go`**: Add facade method for `GetTodayTradesCount()`
- **`contracts.go`**: Add `GetTodayTradesCount()` to `DatabaseService` interface
- **`server.go`**: Add `getTodayTradesCount()` helper method
- **`handler_status.go`**: Use `getTodayTradesCount()` instead of `getTotalTradesCount()` in `/api/status`
- **`index.html`**: Change UI label from "累計" (cumulative) to "本日" (today)