### PR TITLE
feat: add tooltips to risk metric cards for detailed explanations

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -199,17 +199,17 @@
                 </div>
                 <div class="card-body">
                   <div class="grid grid-cols-3 gap-4">
-                    <div>
+                    <div class="tooltip tooltip-bottom" data-tooltip="リスク調整後リターンの指標。&#10;1.0 以上で良好、2.0 以上で優秀。&#10;値が高いほどリスクに対して&#10;効率良くリターンを得ている。">
                       <p class="text-xs text-secondary mb-1">シャープレシオ</p>
                       <p id="sharpe-ratio" class="text-2xl font-bold">-</p>
                       <span class="text-xs text-secondary">目安: &gt;1.0</span>
                     </div>
-                    <div>
+                    <div class="tooltip tooltip-bottom" data-tooltip="総利益 ÷ 総損失の比率。&#10;1.5 以上で良好、2.0 以上で優秀。&#10;1.0 未満は損失が利益を上回る。">
                       <p class="text-xs text-secondary mb-1">プロフィットファクター</p>
                       <p id="profit-factor" class="text-2xl font-bold">-</p>
                       <span class="text-xs text-secondary">目安: &gt;1.5</span>
                     </div>
-                    <div>
+                    <div class="tooltip tooltip-bottom" data-tooltip="資産のピークからの最大下落率。&#10;5% 以下が理想、10% 超は要注意。&#10;小さいほどリスク管理が良好。">
                       <p class="text-xs text-secondary mb-1">最大ドローダウン</p>
                       <p id="max-drawdown" class="text-2xl font-bold">-</p>
                       <span class="text-xs text-secondary">小さいほど良い</span>


### PR DESCRIPTION
## Summary

Add CSS-only tooltips to the three risk metric cards on the performance page, providing detailed explanations on hover.

**Depends on:** bmf-san/sleyt#55 (tooltip component)

## Changes

- **`web/index.html`**: Add `tooltip tooltip-bottom` class and `data-tooltip` attribute to each risk metric card:
  - **Sharpe Ratio**: Explains risk-adjusted return — above 1.0 is good, above 2.0 is excellent
  - **Profit Factor**: Explains total profit / total loss ratio — above 1.5 is good, below 1.0 means losses exceed profits
  - **Max Drawdown**: Explains peak-to-trough decline — below 5% is ideal, above 10% requires attention

Tooltip text is displayed in Japanese since the dashboard UI is in Japanese.

## How it works

Uses sleyt's new `.tooltip` CSS component (v1.4.0) — pure CSS, no JavaScript. Tooltip appears on hover below each metric card.