### PR TITLE
docs: add ETH_JPY as commented-out symbol option in example configs

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -22,6 +22,8 @@ trading:
   fee_rate: 0.0015
   symbols:
     - "XRP_JPY"  # Recommended for low-budget trading (min 1 XRP)
+    # - "XLM_JPY"  # Low-budget option (min 10 XLM, requires order_notional >= 280)
+    # - "ETH_JPY"  # Higher volatility (min 0.01 ETH, requires order_notional >= 5000)
   strategy:
     name: "scalping"
   risk_management:


### PR DESCRIPTION
## Summary

Add ETH_JPY as a commented-out symbol option in both `config.yaml` and `config.example.yaml`.

ETH_JPY offers higher volatility (more signal opportunities for scalping) but requires `order_notional >= 5000` JPY due to the 0.01 ETH minimum order size (~500,000 JPY/ETH × 0.01 = 5,000 JPY).

Since the default `order_notional` is 200 JPY, ETH_JPY is commented out with a note about the minimum requirement.