### PR TITLE
ci: add Dependabot config for gomod and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Add Dependabot configuration for automated dependency updates.

- **gomod**: weekly checks for Go module updates
- **github-actions**: weekly checks for Actions version updates

Commit messages are prefixed with `deps` / `ci` respectively.