### PR TITLE
fix: WS heartbeat ping to prevent NAT timeout disconnects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bmf-san/gogocoin
 go 1.25.0
 
 require (
-	github.com/bmf-san/go-bitflyer-api-client v1.1.0
+	github.com/bmf-san/go-bitflyer-api-client v1.1.1
 	github.com/mattn/go-sqlite3 v1.14.37
 	github.com/oapi-codegen/runtime v1.3.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
-github.com/bmf-san/go-bitflyer-api-client v1.1.0 h1:yr2DRnlNjc2DturB1jj6dfauArP0OpyPOM+2V/VEDXI=
-github.com/bmf-san/go-bitflyer-api-client v1.1.0/go.mod h1:fDVZUdL89mIIGlcCtND1qTaLUh4YWP1/8yPdpS45lE4=
+github.com/bmf-san/go-bitflyer-api-client v1.1.1 h1:jCKwqPeMXXCQrINeH8v8h76qBaw/Iy0C3w+RHKSWOxQ=
+github.com/bmf-san/go-bitflyer-api-client v1.1.1/go.mod h1:fDVZUdL89mIIGlcCtND1qTaLUh4YWP1/8yPdpS45lE4=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/infra/exchange/bitflyer/client.go
+++ b/internal/infra/exchange/bitflyer/client.go
@@ -25,9 +25,10 @@ type Client struct {
 	config *Config
 
 	// State management
-	isConnected bool
-	closed      bool // set to true by Close(); prevents a racing Reconnect from storing a new wsClient
-	mu          sync.RWMutex
+	isConnected     bool
+	closed          bool // set to true by Close(); prevents a racing Reconnect from storing a new wsClient
+	heartbeatCancel context.CancelFunc // cancels the heartbeat goroutine on Close/Reconnect
+	mu              sync.RWMutex
 
 	// rate limiting
 	rateLimiter *RateLimiter
@@ -86,14 +87,14 @@ func (c *Client) initHTTPClient() error {
 	// timezone-less datetime strings returned by the bitFlyer API (e.g.
 	// "2026-03-31T13:08:33") are normalised to RFC3339 UTC ("...Z") before
 	// encoding/json tries to unmarshal them into time.Time fields.
-        httpTimeout := c.config.Timeout
-        if httpTimeout <= 0 {
-                httpTimeout = 30 * time.Second
-        }
-        customHTTPClient := &nethttp.Client{
-                Transport: newDateFixingTransport(nil),
-                Timeout:   httpTimeout,
-        }
+	httpTimeout := c.config.Timeout
+	if httpTimeout <= 0 {
+		httpTimeout = 30 * time.Second
+	}
+	customHTTPClient := &nethttp.Client{
+		Transport: newDateFixingTransport(nil),
+		Timeout:   httpTimeout,
+	}
 
         authClient, err := http.NewAuthenticatedClient(
                 credentials,
@@ -153,10 +154,45 @@ func (c *Client) initWebSocketClient() error {
 	}
 	c.wsClient = client
 	c.isConnected = true
+	hbCtx, hbCancel := context.WithCancel(context.Background())
+	c.heartbeatCancel = hbCancel
 	c.mu.Unlock()
+
+	go c.runHeartbeat(hbCtx)
 
 	c.logger.API().Info("WebSocket client initialized successfully")
 	return nil
+}
+
+// runHeartbeat sends a WebSocket ping every 60 seconds to prevent NAT firewalls
+// from silently dropping the idle TCP connection (typical NAT timeout: 2-5 min).
+// If a ping fails, the client is marked disconnected so the worker reconnects.
+func (c *Client) runHeartbeat(ctx context.Context) {
+	const interval = 60 * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.mu.RLock()
+			ws := c.wsClient
+			c.mu.RUnlock()
+			if ws == nil {
+				return
+			}
+			pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			err := ws.Ping(pingCtx)
+			cancel()
+			if err != nil {
+				c.logger.API().WithError(err).Warn("WebSocket heartbeat ping failed - marking disconnected")
+				c.SetDisconnected()
+				return
+			}
+			c.logger.API().Debug("WebSocket heartbeat ping OK")
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // IsConnected returns the connection state
@@ -184,8 +220,13 @@ func (c *Client) Reconnect(ctx context.Context) error {
 	old := c.wsClient
 	c.wsClient = nil
 	c.isConnected = false
+	oldCancel := c.heartbeatCancel
+	c.heartbeatCancel = nil
 	c.mu.Unlock()
 
+	if oldCancel != nil {
+		oldCancel() // stop old heartbeat before closing
+	}
 	if old != nil {
 		old.Close(ctx)
 	}
@@ -195,6 +236,16 @@ func (c *Client) Reconnect(ctx context.Context) error {
 
 // Close closes the client
 func (c *Client) Close(ctx context.Context) error {
+	c.mu.Lock()
+	c.closed = true // prevent any concurrent Reconnect from storing a new wsClient
+	oldCancel := c.heartbeatCancel
+	c.heartbeatCancel = nil
+	c.mu.Unlock()
+
+	if oldCancel != nil {
+		oldCancel() // stop heartbeat before closing connection
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 


### PR DESCRIPTION
## Problem

VPS NAT was silently dropping idle WebSocket TCP connections after ~3 minutes. Since `staleDataTimeout` was also 3 minutes, the two raced — resulting in a perpetual reconnect loop that triggered bitflyer rate limiting, causing **0 trades**.

Log pattern observed in issue #58:
```
WARN  No market data received for 3m0s, marking disconnected  (every ~3 min)
ERROR use of closed network connection                        (on subscribe after reconnect)
```

## Root Cause

`go-bitflyer-api-client.websocket.NewClient` dials with `&websocket.DialOptions{}` — **no ping interval**. An idle connection (no ticks for 3+ min during low-volatility periods) would be silently dropped by NAT, and the bot would only notice when `staleDataTimeout` fired.

## Fix

Add a **60-second WebSocket heartbeat goroutine** to `Client`:

- Sends `ws.Ping()` every 60 seconds — keeps the NAT entry alive
- If ping fails (connection truly dead), calls `SetDisconnected()` so the worker reconnects immediately
- `heartbeatCancel` stops the goroutine cleanly on `Close()` and `Reconnect()`

Also bumps `go-bitflyer-api-client v1.1.0 → v1.1.1` which adds the `Ping(ctx) error` method.

## Changes

- `internal/infra/exchange/bitflyer/client.go`: added `heartbeatCancel` field, `runHeartbeat()` goroutine, updated `initWebSocketClient()`, `Reconnect()`, `Close()`
- `go.mod`, `go.sum`: bump `go-bitflyer-api-client` to v1.1.1

Supersedes #47 (which had merge conflicts due to timing with #46).