### PR TITLE
fix: do not SetDisconnected when heartbeat ping gets no pong

### DIFF
--- a/internal/infra/exchange/bitflyer/client.go
+++ b/internal/infra/exchange/bitflyer/client.go
@@ -26,7 +26,7 @@ type Client struct {
 
 	// State management
 	isConnected     bool
-	closed          bool // set to true by Close(); prevents a racing Reconnect from storing a new wsClient
+	closed          bool               // set to true by Close(); prevents a racing Reconnect from storing a new wsClient
 	heartbeatCancel context.CancelFunc // cancels the heartbeat goroutine on Close/Reconnect
 	mu              sync.RWMutex
 
@@ -96,11 +96,11 @@ func (c *Client) initHTTPClient() error {
 		Timeout:   httpTimeout,
 	}
 
-        authClient, err := http.NewAuthenticatedClient(
-                credentials,
-                c.config.Endpoint,
-                http.WithCustomHTTPClient(customHTTPClient),
-        )
+	authClient, err := http.NewAuthenticatedClient(
+		credentials,
+		c.config.Endpoint,
+		http.WithCustomHTTPClient(customHTTPClient),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP client: %w", err)
 	}
@@ -166,7 +166,9 @@ func (c *Client) initWebSocketClient() error {
 
 // runHeartbeat sends a WebSocket ping every 60 seconds to prevent NAT firewalls
 // from silently dropping the idle TCP connection (typical NAT timeout: 2-5 min).
-// If a ping fails, the client is marked disconnected so the worker reconnects.
+// The ping frame itself resets the NAT timer even if the server does not reply
+// with a pong (bitflyer does not send pong frames). Dead connections are detected
+// by staleDataTimeout in the market data worker — not here.
 func (c *Client) runHeartbeat(ctx context.Context) {
 	const interval = 60 * time.Second
 	ticker := time.NewTicker(interval)
@@ -184,9 +186,11 @@ func (c *Client) runHeartbeat(ctx context.Context) {
 			err := ws.Ping(pingCtx)
 			cancel()
 			if err != nil {
-				c.logger.API().WithError(err).Warn("WebSocket heartbeat ping failed - marking disconnected")
-				c.SetDisconnected()
-				return
+				// bitflyer does not respond to WS ping frames, so a timeout here
+				// is expected and does not mean the connection is dead.
+				// Continue sending pings to keep the NAT entry alive.
+				c.logger.API().WithError(err).Debug("WebSocket heartbeat ping: no pong (expected for bitflyer)")
+				continue
 			}
 			c.logger.API().Debug("WebSocket heartbeat ping OK")
 		case <-ctx.Done():


### PR DESCRIPTION
## Problem

v1.3.2 (heartbeat ping) made things **worse** than before:

- bitflyer's WS server does not respond to WS ping frames (no pong)
- The 10-second ping timeout fires every 70 seconds
- `SetDisconnected()` is called → worker triggers a reconnect
- Result: **reconnect every 70s** instead of the original **reconnect every 3 min**

Log evidence from v1.3.2:
```
21:28:51 WARN WebSocket heartbeat ping failed - marking disconnected
```
(fired ~70s after startup, then would repeat every 70s)

## Root Cause

The `runHeartbeat` function called `SetDisconnected()` + `return` on any ping error. Since bitflyer never sends pongs, this always triggered after the 10s timeout.

## Fix

- On ping failure: log at `DEBUG` level and `continue` (keep the ticker running)
- **Do not** call `SetDisconnected()` — the ping frame itself resets the NAT entry even without a pong response
- Dead connections are already detected by `staleDataTimeout` in the market data worker

The heartbeat's only job is to send traffic to keep the NAT entry alive, not to detect dead connections.