### PR TITLE
fix: distinguish ping timeout vs connection error in heartbeat

### DIFF
--- a/internal/infra/exchange/bitflyer/client.go
+++ b/internal/infra/exchange/bitflyer/client.go
@@ -166,9 +166,13 @@ func (c *Client) initWebSocketClient() error {
 
 // runHeartbeat sends a WebSocket ping every 60 seconds to prevent NAT firewalls
 // from silently dropping the idle TCP connection (typical NAT timeout: 2-5 min).
-// The ping frame itself resets the NAT timer even if the server does not reply
-// with a pong (bitflyer does not send pong frames). Dead connections are detected
-// by staleDataTimeout in the market data worker — not here.
+//
+// Error handling:
+//   - context.DeadlineExceeded: bitflyer does not send pong frames, so a 10s
+//     timeout is the expected response. The ping frame itself was sent successfully
+//     and resets the NAT timer — treat as healthy.
+//   - Any other error: indicates a genuine TCP-level failure (connection reset,
+//     broken pipe, etc.). Mark the client disconnected so the worker reconnects.
 func (c *Client) runHeartbeat(ctx context.Context) {
 	const interval = 60 * time.Second
 	ticker := time.NewTicker(interval)
@@ -186,11 +190,16 @@ func (c *Client) runHeartbeat(ctx context.Context) {
 			err := ws.Ping(pingCtx)
 			cancel()
 			if err != nil {
-				// bitflyer does not respond to WS ping frames, so a timeout here
-				// is expected and does not mean the connection is dead.
-				// Continue sending pings to keep the NAT entry alive.
-				c.logger.API().WithError(err).Debug("WebSocket heartbeat ping: no pong (expected for bitflyer)")
-				continue
+				if errors.Is(err, context.DeadlineExceeded) {
+					// No pong received within 10s — expected for bitflyer.
+					// The ping frame was still sent, so the NAT entry is reset.
+					c.logger.API().Debug("WebSocket heartbeat ping: no pong (expected for bitflyer, connection healthy)")
+					continue
+				}
+				// Any other error means the TCP connection is genuinely broken.
+				c.logger.API().WithError(err).Warn("WebSocket heartbeat ping: connection error - marking disconnected")
+				c.SetDisconnected()
+				return
 			}
 			c.logger.API().Debug("WebSocket heartbeat ping OK")
 		case <-ctx.Done():


### PR DESCRIPTION
## Problem

After v1.3.3, the heartbeat ignored ALL ping errors including `context.DeadlineExceeded`. This had two consequences:

1. **Genuine TCP failures** (broken pipe, connection reset) after a NAT drop were silently swallowed — the heartbeat kept running on a dead connection
2. **staleDataTimeout** was still the only mechanism to detect dead connections, causing false reconnects when low-volatility pairs (XRP_JPY/XLM_JPY/ETH_JPY at night) produce no tickers for 5+ minutes

Log evidence (still reconnecting every ~5 min after v1.3.3 + 300s timeout):
```
22:19:00 INFO Initializing WebSocket client  ← staleDataTimeout fired at 300s
22:19:10 INFO Initializing WebSocket client  ← subscription failure loop (10s)
22:19:20 INFO Initializing WebSocket client
22:19:30 INFO Initializing WebSocket client
```

## Fix

Distinguish between the two error types in `runHeartbeat`:

| Error | Meaning | Action |
|-------|---------|--------|
| `context.DeadlineExceeded` | No pong within 10s — expected bitflyer behaviour | `continue` (ping frame was sent, NAT entry reset) |
| Any other error | Real TCP failure (broken pipe, connection reset, etc.) | `SetDisconnected()` + `return` |

With this fix, the heartbeat itself detects genuine connection drops within 60 seconds. `stale_data_timeout_seconds` in config can then be set high (e.g. 3600s) to avoid false reconnects on quiet ticker periods.