### PR TITLE
deps: bump go-bitflyer-api-client v1.1.1 → v1.1.2 (TCP keepalive + receive ctx fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bmf-san/gogocoin
 go 1.25.0
 
 require (
-	github.com/bmf-san/go-bitflyer-api-client v1.1.1
+	github.com/bmf-san/go-bitflyer-api-client v1.1.2
 	github.com/mattn/go-sqlite3 v1.14.37
 	github.com/oapi-codegen/runtime v1.3.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
-github.com/bmf-san/go-bitflyer-api-client v1.1.1 h1:jCKwqPeMXXCQrINeH8v8h76qBaw/Iy0C3w+RHKSWOxQ=
-github.com/bmf-san/go-bitflyer-api-client v1.1.1/go.mod h1:fDVZUdL89mIIGlcCtND1qTaLUh4YWP1/8yPdpS45lE4=
+github.com/bmf-san/go-bitflyer-api-client v1.1.2 h1:wau/Fia3HHX0TBzR2w7pNr3XcthUq4sTWs+ai/VdDrw=
+github.com/bmf-san/go-bitflyer-api-client v1.1.2/go.mod h1:fDVZUdL89mIIGlcCtND1qTaLUh4YWP1/8yPdpS45lE4=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
Bumps `go-bitflyer-api-client` from v1.1.1 to v1.1.2.

### What changed in v1.1.2 ([PR #23](https://github.com/bmf-san/go-bitflyer-api-client/pull/23))

Two connection-stability bugs fixed:

**1. receiveMessages goroutine tied to dial context**

`NewClient(ctx)` was forwarding the caller's context to the receive goroutine. `initWebSocketClient()` uses a 30-second timeout context with `defer cancel()`, which fired the moment `initWebSocketClient` returned — cancelling the receive loop's Read context and causing `coder/websocket` to close the connection ~30 s after every (re)connect.

The goroutine now uses `context.WithCancel(context.Background())` and is stopped cleanly by `Close()`.

**2. No TCP keepalive → NAT drops idle connections**

VPS NAT gateways expire idle TCP entries after ~30–60 minutes. During low-volatility overnight periods, bitflyer tickers are quiet enough for the NAT to silently drop the TCP connection. This was the root cause of the hourly "use of closed network connection" reconnect loops and 0-trade daily reports.

TCP keepalive (30 s) is now configured via `net.Dialer`. OS-level probes are fully transparent to bitflyer's application layer. (WS-level ping frames cannot be used — bitflyer closes the connection upon receiving them.)