### PR TITLE
fix(test): use JST in TestInitializeDailyTradeCount to fix UTC CI failure

### DIFF
--- a/pkg/strategy/scalping/strategy_test.go
+++ b/pkg/strategy/scalping/strategy_test.go
@@ -366,7 +366,10 @@ func TestInitializeDailyTradeCount(t *testing.T) {
 	if count != 7 {
 		t.Errorf("expected dailyTradeCount=7, got %d", count)
 	}
-	today := time.Now().Format("2006-01-02")
+	// InitializeDailyTradeCount uses JST (UTC+9), so the expected date must
+	// also be in JST to avoid mismatches in UTC CI environments after 15:00 UTC.
+	jst := time.FixedZone("JST", 9*60*60)
+	today := time.Now().In(jst).Format("2006-01-02")
 	if date != today {
 		t.Errorf("expected lastTradeDate=%s, got %s", today, date)
 	}


### PR DESCRIPTION
## Problem

`TestInitializeDailyTradeCount` was failing in CI:

```
strategy_test.go:371: expected lastTradeDate=2026-03-20, got 2026-03-21
```

`InitializeDailyTradeCount` sets `lastTradeDate` in **JST (UTC+9)**:

```go
s.lastTradeDate = time.Now().UTC().Add(9 * time.Hour).Format("2006-01-02")
```

But the test was comparing it against `time.Now().Format("2006-01-02")` which uses the system's local time. In the UTC CI environment, after **15:00 UTC** (= 00:00 JST next day), the implementation returns tomorrow's JST date while `time.Now()` still returns today's UTC date — a one-day mismatch.

## Fix

Use `time.FixedZone("JST", 9*60*60)` in the test assertion to match the JST date the implementation produces.