### PR TITLE
fix: log bitflyer error response body on order 400

### DIFF
--- a/internal/usecase/trading/order/order_service.go
+++ b/internal/usecase/trading/order/order_service.go
@@ -3,6 +3,7 @@ package order
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/bmf-san/go-bitflyer-api-client/client/http"
@@ -64,10 +65,9 @@ func (s *OrderService) PlaceOrder(ctx context.Context, order *domain.OrderReques
 		s.logger.LogAPICall("POST", "/v1/me/sendchildorder", callDuration, resp.HTTPResponse.StatusCode, nil)
 
 		if resp.HTTPResponse.StatusCode != 200 {
-			return fmt.Errorf("API error: status %d", resp.HTTPResponse.StatusCode)
-		}
-
-		if resp.JSON200 == nil {
+				body, _ := io.ReadAll(resp.HTTPResponse.Body)
+				s.logger.Trading().WithField("status", resp.HTTPResponse.StatusCode).WithField("response_body", string(body)).Error("bitflyer API rejected order")
+				return fmt.Errorf("API error: status %d, body: %s", resp.HTTPResponse.StatusCode, string(body))
 			return fmt.Errorf("empty response body")
 		}
 

--- a/pkg/strategy/scalping/strategy_test.go
+++ b/pkg/strategy/scalping/strategy_test.go
@@ -366,7 +366,10 @@ func TestInitializeDailyTradeCount(t *testing.T) {
 	if count != 7 {
 		t.Errorf("expected dailyTradeCount=7, got %d", count)
 	}
-	today := time.Now().Format("2006-01-02")
+	// InitializeDailyTradeCount uses JST (UTC+9), so the expected date must
+	// also be in JST to avoid mismatches in UTC CI environments after 15:00 UTC.
+	jst := time.FixedZone("JST", 9*60*60)
+	today := time.Now().In(jst).Format("2006-01-02")
 	if date != today {
 		t.Errorf("expected lastTradeDate=%s, got %s", today, date)
 	}


### PR DESCRIPTION
## Problem

When bitflyer rejects an order with HTTP 400, the log only showed:

```
"Failed to place order" error="failed to place order after retries: API error: status 400"
```

The bitflyer response body (which contains `error_message` like `"Insufficient funds"` or `"The minimum order size is..."`) was silently discarded, making it impossible to diagnose WHY the order was rejected.

**Triggered by:** ETH_JPY MARKET BUY @ 342,113 JPY was rejected on 2026-03-21 08:46:38 JST with status 400 — root cause is unknown because the body was not logged.

## Fix

Read `resp.HTTPResponse.Body` on non-200 status and include it in:
1. A structured log field: `response_body={"status":-1,"error_message":"..."}`
2. The returned error string (propagated via `WithRetry` → `Failed to place order`)

## After this fix the log will show

```json
{"level":"ERROR","msg":"bitflyer API rejected order","status":400,"response_body":"{\"status\":-1,\"error_message\":\"Insufficient funds.\",\"data\":null}"}
{"level":"ERROR","msg":"Failed to place order","error":"failed to place order after retries: API error: status 400, body: {\"status\":-1,...}"}
```