### PR TITLE
fix: remove misleading 'Check API credentials' hint on order error

### DIFF
--- a/internal/adapter/worker/signal_worker.go
+++ b/internal/adapter/worker/signal_worker.go
@@ -143,7 +143,6 @@ func (w *SignalWorker) processSignal(ctx context.Context, signal *strategy.Signa
 	result, err := w.trader.PlaceOrder(ctx, &order)
 	if err != nil {
 		w.logger.Trading().WithError(err).Error("Failed to place order")
-		w.logger.Trading().Info("Check API credentials and account permissions")
 		return
 	}
 


### PR DESCRIPTION
The message `"Check API credentials and account permissions"` was a static hint emitted after every `PlaceOrder` failure, regardless of the actual cause (HTTP 400, insufficient funds, min order size violation, etc.).\n\nIt gave the false impression that the API key/secret were wrong, when in reality the order was rejected for a completely different reason.\n\nWith `v1.3.8` now logging the actual bitflyer response body on 400 errors, this generic hint provides no additional diagnostic value and is removed.