### PR TITLE
fix(sell): apply runtime config defaults and fix dust-lot fallback in getAvailableSellSize

### DIFF
--- a/internal/adapter/worker/signal_worker.go
+++ b/internal/adapter/worker/signal_worker.go
@@ -413,11 +413,24 @@ func (w *SignalWorker) getAvailableSellSize(ctx context.Context, symbol string, 
 		return requestedSize
 	}
 
-	// Sell a portion of holdings rounded down to the nearest lot size
+	// Sell a portion of holdings rounded down to the nearest lot size.
 	lotSize := w.resolveLotsSize(symbol)
 	result := math.Floor(availableBalance*w.sellSizePercentage/lotSize) * lotSize
 	if result <= 0 {
-		return availableBalance * w.sellSizePercentage
+		// The percentage-adjusted balance rounds down to zero lots (e.g. dust just
+		// below a lot boundary with sell_size_percentage < 1.0).  Fall back to
+		// selling exactly one lot when the raw balance covers it, rather than
+		// sending a non-lot-rounded quantity that the exchange would reject.
+		if availableBalance >= lotSize {
+			return lotSize
+		}
+		// Balance is below the minimum lot size; cannot place a valid sell order.
+		w.logger.Trading().
+			WithField("symbol", symbol).
+			WithField("available", availableBalance).
+			WithField("lot_size", lotSize).
+			Warn("Available balance below minimum lot size – cannot place SELL order")
+		return 0
 	}
 	return result
 }

--- a/internal/adapter/worker/signal_worker_test.go
+++ b/internal/adapter/worker/signal_worker_test.go
@@ -499,3 +499,105 @@ func TestGetAutoScaleConfig_InvalidBalancePctClamped(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tests: getAvailableSellSize
+// ---------------------------------------------------------------------------
+
+func newSellWorker(t *testing.T, balances []domain.Balance, sellPct float64) *SignalWorker {
+	t.Helper()
+	log := createTestLogger(t)
+	trader := &mockTrader{balances: balances}
+	return &SignalWorker{
+		logger:               log,
+		signalCh:             make(chan *strategy.Signal),
+		tradingEnabledGetter: &mockTradingEnabledGetter{enabled: true},
+		riskChecker:          &mockRiskChecker{},
+		trader:               trader,
+		currentStrategy:      newMockStrategy(nil),
+		performanceUpdater:   &mockPerformanceUpdater{},
+		lotSizeSvc: &mockLotSizeService{sizes: map[string]float64{
+			"ETH_JPY": 0.01,
+			"XRP_JPY": 1.0,
+			"BTC_JPY": 0.001,
+		}},
+		sellSizePercentage: sellPct,
+	}
+}
+
+func TestGetAvailableSellSize(t *testing.T) {
+	tests := []struct {
+		name          string
+		symbol        string
+		balances      []domain.Balance
+		requestedSize float64
+		sellPct       float64
+		want          float64
+	}{
+		{
+			name:          "no holdings returns 0",
+			symbol:        "ETH_JPY",
+			balances:      []domain.Balance{{Currency: "JPY", Available: 100000}},
+			requestedSize: 0.01,
+			sellPct:       0.95,
+			want:          0,
+		},
+		{
+			name:          "requestedSize < available returns requestedSize",
+			symbol:        "ETH_JPY",
+			balances:      []domain.Balance{{Currency: "ETH", Available: 0.05}},
+			requestedSize: 0.01,
+			sellPct:       0.95,
+			want:          0.01,
+		},
+		{
+			name:          "requestedSize > available applies lot-floor",
+			symbol:        "ETH_JPY",
+			balances:      []domain.Balance{{Currency: "ETH", Available: 0.029964}},
+			requestedSize: 0.03,
+			sellPct:       0.95,
+			// floor(0.029964 * 0.95 / 0.01) * 0.01 = floor(2.84658) * 0.01 = 0.02
+			want: 0.02,
+		},
+		{
+			name:          "XRP full balance > requestedSize applies lot-floor",
+			symbol:        "XRP_JPY",
+			balances:      []domain.Balance{{Currency: "XRP", Available: 7}},
+			requestedSize: 100,
+			sellPct:       0.95,
+			// floor(7 * 0.95 / 1.0) * 1.0 = floor(6.65) = 6
+			want: 6,
+		},
+		{
+			// When percentage rounding floors to 0 lots but balance >= 1 lot,
+			// fall back to exactly 1 lot rather than sending a non-lot-rounded
+			// quantity that the exchange would reject.
+			name:    "sell_size_pct rounds to 0 lots but balance covers 1 lot – returns 1 lot",
+			symbol:  "ETH_JPY",
+			balances: []domain.Balance{{Currency: "ETH", Available: 0.0105}},
+			// 0.0105 * 0.95 = 0.009975 → floor(0.009975/0.01)*0.01 = 0
+			requestedSize: 0.03,
+			sellPct:       0.95,
+			want:          0.01, // 1 lot
+		},
+		{
+			// Balance below minimum lot size – must return 0 (can't place valid order).
+			name:          "balance below lot size returns 0",
+			symbol:        "ETH_JPY",
+			balances:      []domain.Balance{{Currency: "ETH", Available: 0.009}},
+			requestedSize: 0.03,
+			sellPct:       0.95,
+			want:          0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newSellWorker(t, tc.balances, tc.sellPct)
+			got := w.getAvailableSellSize(context.Background(), tc.symbol, tc.requestedSize)
+			if math.Abs(got-tc.want) > 1e-9 {
+				t.Errorf("getAvailableSellSize(%s, %v) = %v; want %v", tc.symbol, tc.requestedSize, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,6 +282,28 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("worker.max_concurrent_saves must be positive")
 	}
 
+	// Apply default runtime configuration when fields are zero / not present in YAML.
+	// Without this, omitting the [runtime] section causes sell_size_percentage to be
+	// 0.0 (Go zero value), which makes getAvailableSellSize always return 0 and every
+	// SELL signal to be skipped with "no crypto holdings available".
+	{
+		runtimeDefaults := DefaultStrategyRuntimeConfig()
+		if c.Runtime.SellSizePercentage == 0 {
+			c.Runtime.SellSizePercentage = runtimeDefaults.SellSizePercentage
+		}
+		if c.Runtime.HistoryLimit == 0 {
+			c.Runtime.HistoryLimit = runtimeDefaults.HistoryLimit
+		}
+		if c.Runtime.SignalStrengthThreshold == 0 {
+			c.Runtime.SignalStrengthThreshold = runtimeDefaults.SignalStrengthThreshold
+		}
+	}
+
+	// Validate runtime configuration
+	if c.Runtime.SellSizePercentage <= 0 || c.Runtime.SellSizePercentage > 1 {
+		return fmt.Errorf("runtime.sell_size_percentage must be between 0 (exclusive) and 1 (inclusive), got %v", c.Runtime.SellSizePercentage)
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -353,3 +353,83 @@ func TestExpandEnvVars_UndefinedVariable(t *testing.T) {
 		t.Errorf("Expected '%s', got '%s'", expected, result)
 	}
 }
+
+// TestValidate_RuntimeDefaultsApplied verifies that omitting the [runtime]
+// section from the config YAML results in sell_size_percentage being set to
+// the default value (0.95) rather than the Go zero value (0.0).
+// A zero sell_size_percentage causes getAvailableSellSize to always return 0,
+// which silently skips every SELL signal with "no crypto holdings available".
+func TestValidate_RuntimeDefaultsApplied(t *testing.T) {
+	cfg := &Config{
+		App: AppConfig{Name: "test"},
+		API: APIConfig{
+			Endpoint:          "https://api.example.com",
+			WebSocketEndpoint: "wss://ws.example.com",
+			Credentials:       CredentialsConfig{APIKey: "k", APISecret: "s"},
+		},
+		Trading: TradingConfig{
+			InitialBalance: 10000,
+			Symbols:        []string{"BTC_JPY"},
+			Strategy:       StrategyConfig{Name: "scalping"},
+			RiskManagement: RiskManagementConfig{
+				MaxTotalLossPercent:   10,
+				MaxTradeAmountPercent: 5,
+			},
+		},
+		UI: UIConfig{Port: 8080},
+		// Runtime intentionally left as zero value (as if absent from YAML).
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	got := cfg.Runtime.SellSizePercentage
+	want := DefaultStrategyRuntimeConfig().SellSizePercentage
+	if got != want {
+		t.Errorf("SellSizePercentage after Validate() = %v; want %v (default)", got, want)
+	}
+}
+
+// TestValidate_RuntimeInvalidSellSizePercentage verifies that an explicitly
+// invalid sell_size_percentage (out of range) is rejected at startup.
+func TestValidate_RuntimeInvalidSellSizePercentage(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			App: AppConfig{Name: "test"},
+			API: APIConfig{
+				Endpoint:          "https://api.example.com",
+				WebSocketEndpoint: "wss://ws.example.com",
+				Credentials:       CredentialsConfig{APIKey: "k", APISecret: "s"},
+			},
+			Trading: TradingConfig{
+				InitialBalance: 10000,
+				Symbols:        []string{"BTC_JPY"},
+				Strategy:       StrategyConfig{Name: "scalping"},
+				RiskManagement: RiskManagementConfig{
+					MaxTotalLossPercent:   10,
+					MaxTradeAmountPercent: 5,
+				},
+			},
+			UI: UIConfig{Port: 8080},
+		}
+	}
+
+	tests := []struct {
+		name string
+		pct  float64
+	}{
+		{"negative", -0.1},
+		{"above 1", 1.1},
+		{"exactly 0 after default applied – should not happen but explicit 0 via re-set", -0.0001},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base()
+			cfg.Runtime.SellSizePercentage = tc.pct
+			if err := cfg.Validate(); err == nil {
+				t.Errorf("Validate() expected error for SellSizePercentage=%v, got nil", tc.pct)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two bugs that could silently skip every SELL signal, found during a thorough audit of the buy/sell trading logic.

---

## Bug 1 — Root cause: `config.Validate()` does not apply `runtime` defaults

### Problem

When the `[runtime]` section is absent from `config.yaml`, `sell_size_percentage` is left as the Go zero value `0.0`.  
`getAvailableSellSize()` then computes:

```
floor(balance * 0.0 / lotSize) * lotSize = 0
// fallback:
return balance * 0.0 = 0
```

Every SELL signal is skipped with **"Skipping SELL signal - no crypto holdings available"**, even when the wallet holds crypto. This is the root cause of the production issue observed on the VPS (PR #79 in `my-gogocoin` adds `runtime.sell_size_percentage: 0.95` as a workaround).

### Fix (`internal/config/config.go`)

Apply `DefaultStrategyRuntimeConfig()` defaults in `Validate()`, exactly as the `worker` config already does:

```go
runtimeDefaults := DefaultStrategyRuntimeConfig()
if c.Runtime.SellSizePercentage == 0 {
    c.Runtime.SellSizePercentage = runtimeDefaults.SellSizePercentage  // 0.95
}
```

Also added a validation that `sell_size_percentage` must be in `(0, 1]` to catch invalid explicit values at startup.

---

## Bug 2 — `getAvailableSellSize` returns a non-lot-rounded quantity when floor gives 0

### Problem

When `availableBalance * sellSizePercentage` is just below a lot boundary (e.g. `0.0105 ETH * 0.95 = 0.009975`, lot `0.01`), `math.Floor` gives 0 lots.  
The old fallback returned `availableBalance * sellSizePercentage = 0.009975` — a quantity the exchange **rejects** because it is below the minimum lot size.

### Fix (`internal/adapter/worker/signal_worker.go`)

```go
if result <= 0 {
    if availableBalance >= lotSize {
        return lotSize  // sell exactly 1 lot
    }
    // balance is below minimum lot size – cannot place a valid order
    return 0
}
```

---

## Tests

- `TestValidate_RuntimeDefaultsApplied` — confirms `sell_size_percentage` is `0.95` when `[runtime]` is omitted  
- `TestValidate_RuntimeInvalidSellSizePercentage` — confirms out-of-range values are rejected at startup  
- `TestGetAvailableSellSize` — covers all cases: no holdings, requested < available, floor-to-0 fallback, balance below lot size