### PR TITLE
fix(position): include PARTIAL positions in stop-loss and active position queries

### DIFF
--- a/internal/adapter/worker/stop_loss_test.go
+++ b/internal/adapter/worker/stop_loss_test.go
@@ -158,6 +158,29 @@ func TestCheckStopLoss_MultiplePositions_OnlyOneBreached(t *testing.T) {
 	}
 }
 
+func TestCheckStopLoss_PartialPosition_Triggered(t *testing.T) {
+	// Real BitFlyer positions transition OPEN→PARTIAL once partially matched.
+	// Stop-loss must fire on PARTIAL positions, not only OPEN ones.
+	w := newTestStrategyWorker(t, map[string]any{"stop_loss_pct": 1.0})
+	w.SetPositionReader(&mockPositionReader{
+		positions: []domain.Position{
+			{Symbol: "XRP_JPY", Side: "BUY", EntryPrice: 229.01, Status: "PARTIAL"},
+		},
+	})
+
+	// 1% below 229.01 = 226.7199; current price 226.29 is below stop → trigger
+	got := w.checkStopLoss("XRP_JPY", 226.29)
+	if got == nil {
+		t.Fatal("expected SELL signal for PARTIAL position below stop price, got nil")
+	}
+	if got.Action != strategy.SignalSell {
+		t.Fatalf("expected SignalSell, got %v", got.Action)
+	}
+	if got.Metadata["reason"] != "stop_loss" {
+		t.Fatalf("expected reason=stop_loss, got %v", got.Metadata["reason"])
+	}
+}
+
 func TestGetStopLossPct_NotConfigured(t *testing.T) {
 	w := newTestStrategyWorker(t, map[string]any{})
 	if pct := w.getStopLossPct(); pct != 0 {

--- a/internal/infra/persistence/persistence_test.go
+++ b/internal/infra/persistence/persistence_test.go
@@ -99,6 +99,40 @@ func TestPositionRepository_SaveAndGetOpen(t *testing.T) {
 	}
 }
 
+func TestPositionRepository_GetOpenPositions_IncludesPartial(t *testing.T) {
+	db := newTestDB(t)
+	repo := persistence.NewPositionRepository(db)
+
+	// PARTIAL position: partially filled, remaining_size > 0 — stop-loss must see this.
+	partial := &domain.Position{
+		Symbol: "XRP_JPY", Side: "BUY",
+		Size: 10, UsedSize: 3, RemainingSize: 7, EntryPrice: 229.0, CurrentPrice: 226.0,
+		Status: "PARTIAL", OrderID: "POS-PARTIAL",
+	}
+	// CLOSED position: must NOT be returned.
+	closed := &domain.Position{
+		Symbol: "XRP_JPY", Side: "BUY",
+		Size: 5, UsedSize: 5, RemainingSize: 0, EntryPrice: 220.0, CurrentPrice: 226.0,
+		Status: "CLOSED", OrderID: "POS-CLOSED",
+	}
+	for _, p := range []*domain.Position{partial, closed} {
+		if err := repo.SavePosition(p); err != nil {
+			t.Fatalf("SavePosition %s: %v", p.OrderID, err)
+		}
+	}
+
+	positions, err := repo.GetOpenPositions("XRP_JPY", "BUY")
+	if err != nil {
+		t.Fatalf("GetOpenPositions: %v", err)
+	}
+	if len(positions) != 1 {
+		t.Fatalf("expected 1 position (PARTIAL), got %d: %v", len(positions), positions)
+	}
+	if positions[0].OrderID != "POS-PARTIAL" {
+		t.Errorf("expected POS-PARTIAL, got %v", positions[0].OrderID)
+	}
+}
+
 func TestPositionRepository_UpdatePosition(t *testing.T) {
 	db := newTestDB(t)
 	repo := persistence.NewPositionRepository(db)

--- a/internal/infra/persistence/position_repo.go
+++ b/internal/infra/persistence/position_repo.go
@@ -32,12 +32,14 @@ func (r *PositionRepository) SavePosition(position *domain.Position) error {
 	return err
 }
 
-// GetOpenPositions returns OPEN positions for symbol+side with remaining_size > 0, ordered oldest first.
+// GetOpenPositions returns OPEN and PARTIAL positions for symbol+side with remaining_size > 0, ordered oldest first.
+// Both statuses are included because real exchange fills move positions from OPEN→PARTIAL before CLOSED,
+// and stop-loss checks must see partially-filled positions to function correctly.
 func (r *PositionRepository) GetOpenPositions(symbol string, side string) ([]domain.Position, error) {
 	query := `SELECT id, symbol, side, size, used_size, remaining_size, entry_price,
 			  current_price, unrealized_pl, status, order_id, created_at, updated_at
 			  FROM positions
-			  WHERE symbol = ? AND side = ? AND status = 'OPEN' AND remaining_size > 0
+			  WHERE symbol = ? AND side = ? AND status IN ('OPEN', 'PARTIAL') AND remaining_size > 0
 			  ORDER BY created_at ASC`
 	rows, err := r.db.db.Query(query, symbol, side)
 	if err != nil {
@@ -70,11 +72,11 @@ func (r *PositionRepository) UpdatePosition(position *domain.Position) error {
 	return err
 }
 
-// GetActivePositions returns all positions with status='OPEN' and size != 0.
+// GetActivePositions returns all OPEN and PARTIAL positions with size != 0.
 func (r *PositionRepository) GetActivePositions() ([]domain.Position, error) {
 	query := `SELECT id, symbol, side, size, used_size, remaining_size, entry_price,
 			  current_price, unrealized_pl, pnl, status, order_id, created_at, updated_at
-			  FROM positions WHERE size != 0 AND status = 'OPEN' ORDER BY created_at DESC`
+			  FROM positions WHERE size != 0 AND status IN ('OPEN', 'PARTIAL') ORDER BY created_at DESC`
 	rows, err := r.db.db.Query(query)
 	if err != nil {
 		return nil, err
@@ -93,10 +95,10 @@ func (r *PositionRepository) GetActivePositions() ([]domain.Position, error) {
 	return positions, rows.Err()
 }
 
-// GetActivePositionsCount returns the count of OPEN positions.
+// GetActivePositionsCount returns the count of OPEN and PARTIAL positions.
 func (r *PositionRepository) GetActivePositionsCount() (int, error) {
 	var count int
-	err := r.db.db.QueryRow("SELECT COUNT(*) FROM positions WHERE status = ?", "OPEN").Scan(&count)
+	err := r.db.db.QueryRow("SELECT COUNT(*) FROM positions WHERE status IN ('OPEN', 'PARTIAL')").Scan(&count)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Problem

BitFlyer orders go through a `PARTIAL` status before being fully filled.
The previous queries filtered only `status = 'OPEN'`, so stop-loss checks and the web UI display both silently ignored all `PARTIAL` positions.

### Impact

| Feature | Symptom |
|---|---|
| Stop-loss | Never fires on `PARTIAL` positions |
| Web UI positions display | Active position count and list always show zero |

## Changes

`WHERE status = 'OPEN'` → `WHERE status IN ('OPEN', 'PARTIAL')` applied consistently:

- `GetOpenPositions` — used by stop-loss check; this is the primary fix
- `GetActivePositions` — used by the web UI positions display; same bug fixed
- `GetActivePositionsCount` — used for position count; same bug fixed

## Tests Added

- `TestPositionRepository_GetOpenPositions_IncludesPartial` — verifies `PARTIAL` positions are returned and `CLOSED` positions are not
- `TestCheckStopLoss_PartialPosition_Triggered` — verifies a SELL signal is generated when a `PARTIAL` position breaches its stop price

## Reproduction

Confirmed on the running VPS: XRP_JPY positions with entries at ¥229.51 and ¥229.01 (both `PARTIAL`) had stop prices of ¥227.22 and ¥226.72 respectively. With XRP price at ¥226.29, stop-loss should have fired but never did until this fix.