### PR TITLE
fix(position): auto-close ghost PARTIAL positions when stop-loss SELL skips due to dust

### DIFF
--- a/internal/adapter/worker/contracts.go
+++ b/internal/adapter/worker/contracts.go
@@ -43,3 +43,10 @@ type PositionReader interface {
 	GetOpenPositions(symbol string, side string) ([]domain.Position, error)
 }
 
+// PositionCloser marks all open/partial positions for a symbol+side as CLOSED.
+// Used by SignalWorker to discard ghost positions when the actual exchange
+// balance is below the minimum lot size and a stop-loss SELL cannot execute.
+type PositionCloser interface {
+	CloseOpenPositions(symbol string, side string) error
+}
+

--- a/internal/adapter/worker/signal_worker.go
+++ b/internal/adapter/worker/signal_worker.go
@@ -32,6 +32,9 @@ type SignalWorker struct {
 	// (< 1.0 to avoid rounding errors). Loaded from config at startup.
 	sellSizePercentage float64
 	wg                 sync.WaitGroup // Tracks background goroutines for graceful shutdown
+	// positionCloser is optional; when set, ghost PARTIAL positions are closed
+	// automatically when a stop-loss SELL cannot execute due to dust balance.
+	positionCloser PositionCloser
 }
 
 // TradingEnabledGetter defines the interface for checking if trading is enabled
@@ -84,6 +87,11 @@ func NewSignalWorker(
 		sellSizePercentage:   sellSizePercentage,
 	}
 }
+
+// SetPositionCloser injects an optional PositionCloser. When set, ghost
+// PARTIAL positions are automatically closed if a stop-loss SELL is skipped
+// because the actual exchange balance is below the minimum lot size.
+func (w *SignalWorker) SetPositionCloser(c PositionCloser) { w.positionCloser = c }
 
 // Name returns the worker name.
 func (w *SignalWorker) Name() string { return "signal-worker" }
@@ -143,6 +151,14 @@ func (w *SignalWorker) processSignal(ctx context.Context, signal *strategy.Signa
 	// Create order (pass context for balance checking)
 	order, skip := w.createOrderFromSignal(ctx, signal)
 	if skip {
+		// If a stop-loss SELL was skipped because the exchange balance is dust
+		// (below the minimum lot size), close the ghost PARTIAL positions in the
+		// DB so stop-loss stops firing on already-liquidated positions.
+		if signal.Action == strategy.SignalSell {
+			if reason, ok := signal.Metadata["reason"].(string); ok && reason == "stop_loss" {
+				w.closeGhostPositions(signal.Symbol)
+			}
+		}
 		return
 	}
 
@@ -433,6 +449,21 @@ func (w *SignalWorker) getAvailableSellSize(ctx context.Context, symbol string, 
 		return 0
 	}
 	return result
+}
+
+// closeGhostPositions marks all open/partial BUY positions for symbol as CLOSED
+// when a stop-loss SELL cannot execute because exchange balance is dust.
+func (w *SignalWorker) closeGhostPositions(symbol string) {
+	if w.positionCloser == nil {
+		return
+	}
+	if err := w.positionCloser.CloseOpenPositions(symbol, "BUY"); err != nil {
+		w.logger.Trading().WithError(err).WithField("symbol", symbol).
+			Warn("Failed to close ghost positions after dust stop-loss skip")
+		return
+	}
+	w.logger.Trading().WithField("symbol", symbol).
+		Info("Closed ghost PARTIAL positions — balance was dust (below minimum lot size)")
 }
 
 // resolveLotsSize returns the minimum lot size for a symbol using the injected

--- a/internal/adapter/worker/signal_worker_test.go
+++ b/internal/adapter/worker/signal_worker_test.go
@@ -601,3 +601,98 @@ func TestGetAvailableSellSize(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Ghost position auto-close tests
+// ---------------------------------------------------------------------------
+
+type mockPositionCloser struct {
+	closed []string // "symbol:side" entries
+	err    error
+}
+
+func (m *mockPositionCloser) CloseOpenPositions(symbol, side string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.closed = append(m.closed, symbol+":"+side)
+	return nil
+}
+
+func TestProcessSignal_StopLossDust_ClosesGhostPositions(t *testing.T) {
+	// When a stop-loss SELL signal cannot execute because the exchange balance
+	// is below the minimum lot size, the signal worker must close the ghost
+	// PARTIAL positions so stop-loss stops firing on them every tick.
+	log := createTestLogger(t)
+	signalCh := make(chan *strategy.Signal, 1)
+
+	closer := &mockPositionCloser{}
+	w := &SignalWorker{
+		logger:               log,
+		signalCh:             signalCh,
+		tradingEnabledGetter: &mockTradingEnabledGetter{enabled: true},
+		riskChecker:          &mockRiskChecker{},
+		trader: &mockTrader{
+			// XRP balance is dust — below 1 XRP lot
+			balances: []domain.Balance{{Currency: "XRP", Available: 0.06717, Amount: 0.06717}},
+		},
+		currentStrategy:    &mockSignalStrategy{},
+		performanceUpdater: &mockPerformanceUpdater{},
+		lotSizeSvc: &mockLotSizeService{sizes: map[string]float64{
+			"XRP_JPY": 1.0,
+		}},
+		sellSizePercentage: 0.95,
+		positionCloser:     closer,
+	}
+
+	sig := &strategy.Signal{
+		Symbol: "XRP_JPY",
+		Action: strategy.SignalSell,
+		Price:  222.64,
+		Metadata: map[string]interface{}{
+			"reason": "stop_loss",
+		},
+	}
+	w.processSignal(context.Background(), sig)
+
+	if len(closer.closed) != 1 || closer.closed[0] != "XRP_JPY:BUY" {
+		t.Errorf("expected ghost positions closed for XRP_JPY:BUY, got %v", closer.closed)
+	}
+}
+
+func TestProcessSignal_NormalSell_DoesNotClosePositions(t *testing.T) {
+	// A regular (non-stop-loss) SELL skipped due to no balance must NOT
+	// trigger ghost position cleanup.
+	log := createTestLogger(t)
+	signalCh := make(chan *strategy.Signal, 1)
+
+	closer := &mockPositionCloser{}
+	w := &SignalWorker{
+		logger:               log,
+		signalCh:             signalCh,
+		tradingEnabledGetter: &mockTradingEnabledGetter{enabled: true},
+		riskChecker:          &mockRiskChecker{},
+		trader: &mockTrader{
+			balances: []domain.Balance{{Currency: "XRP", Available: 0.0, Amount: 0.0}},
+		},
+		currentStrategy:    &mockSignalStrategy{},
+		performanceUpdater: &mockPerformanceUpdater{},
+		lotSizeSvc: &mockLotSizeService{sizes: map[string]float64{
+			"XRP_JPY": 1.0,
+		}},
+		sellSizePercentage: 0.95,
+		positionCloser:     closer,
+	}
+
+	sig := &strategy.Signal{
+		Symbol:   "XRP_JPY",
+		Action:   strategy.SignalSell,
+		Price:    222.64,
+		Metadata: map[string]interface{}{}, // no "reason" = normal SELL
+	}
+	w.processSignal(context.Background(), sig)
+
+	if len(closer.closed) != 0 {
+		t.Errorf("normal SELL skip must not close ghost positions, got %v", closer.closed)
+	}
+}

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -12,6 +12,10 @@ type PositionRepository interface {
 	SavePosition(position *Position) error
 	GetOpenPositions(symbol string, side string) ([]Position, error)
 	UpdatePosition(position *Position) error
+	// CloseOpenPositions sets all OPEN/PARTIAL positions for the given
+	// symbol+side to CLOSED. Used to discard ghost positions when the
+	// actual exchange balance has fallen below the minimum lot size.
+	CloseOpenPositions(symbol string, side string) error
 }
 
 // BalanceRepository is the interface for balance data persistence

--- a/internal/infra/persistence/persistence_test.go
+++ b/internal/infra/persistence/persistence_test.go
@@ -99,6 +99,37 @@ func TestPositionRepository_SaveAndGetOpen(t *testing.T) {
 	}
 }
 
+func TestPositionRepository_CloseOpenPositions(t *testing.T) {
+	db := newTestDB(t)
+	repo := persistence.NewPositionRepository(db)
+
+	for _, p := range []*domain.Position{
+		{Symbol: "XRP_JPY", Side: "BUY", Size: 10, RemainingSize: 10, EntryPrice: 229.0, Status: "OPEN", OrderID: "POS-A"},
+		{Symbol: "XRP_JPY", Side: "BUY", Size: 10, UsedSize: 3, RemainingSize: 7, EntryPrice: 229.0, Status: "PARTIAL", OrderID: "POS-B"},
+		{Symbol: "ETH_JPY", Side: "BUY", Size: 1, RemainingSize: 1, EntryPrice: 343000.0, Status: "OPEN", OrderID: "POS-C"},
+	} {
+		if err := repo.SavePosition(p); err != nil {
+			t.Fatalf("SavePosition %s: %v", p.OrderID, err)
+		}
+	}
+
+	if err := repo.CloseOpenPositions("XRP_JPY", "BUY"); err != nil {
+		t.Fatalf("CloseOpenPositions: %v", err)
+	}
+
+	// XRP_JPY BUY positions must now be gone
+	xrp, _ := repo.GetOpenPositions("XRP_JPY", "BUY")
+	if len(xrp) != 0 {
+		t.Errorf("expected 0 XRP_JPY positions after close, got %d", len(xrp))
+	}
+
+	// ETH_JPY position must be untouched
+	eth, _ := repo.GetOpenPositions("ETH_JPY", "BUY")
+	if len(eth) != 1 {
+		t.Errorf("expected ETH_JPY position to be untouched, got %d", len(eth))
+	}
+}
+
 func TestPositionRepository_GetOpenPositions_IncludesPartial(t *testing.T) {
 	db := newTestDB(t)
 	repo := persistence.NewPositionRepository(db)

--- a/internal/infra/persistence/position_repo.go
+++ b/internal/infra/persistence/position_repo.go
@@ -59,6 +59,19 @@ func (r *PositionRepository) GetOpenPositions(symbol string, side string) ([]dom
 	return positions, rows.Err()
 }
 
+// CloseOpenPositions marks all OPEN/PARTIAL positions for symbol+side as CLOSED.
+// Called when a stop-loss SELL cannot be executed because the actual exchange
+// balance is dust (below the minimum lot size), to keep the DB in sync.
+func (r *PositionRepository) CloseOpenPositions(symbol string, side string) error {
+	now := time.Now()
+	_, err := r.db.db.Exec(
+		`UPDATE positions SET status = 'CLOSED', updated_at = ?
+		  WHERE symbol = ? AND side = ? AND status IN ('OPEN', 'PARTIAL')`,
+		now, symbol, side,
+	)
+	return err
+}
+
 // UpdatePosition updates a position by order_id.
 func (r *PositionRepository) UpdatePosition(position *domain.Position) error {
 	position.UpdatedAt = time.Now()

--- a/internal/infra/persistence/repository.go
+++ b/internal/infra/persistence/repository.go
@@ -61,6 +61,9 @@ func (r *Repository) GetOpenPositions(symbol string, side string) ([]domain.Posi
 func (r *Repository) UpdatePosition(position *domain.Position) error {
 	return r.position.UpdatePosition(position)
 }
+func (r *Repository) CloseOpenPositions(symbol string, side string) error {
+	return r.position.CloseOpenPositions(symbol, side)
+}
 func (r *Repository) GetActivePositions() ([]domain.Position, error) {
 	return r.position.GetActivePositions()
 }

--- a/internal/usecase/trading/pnl/calculator_test.go
+++ b/internal/usecase/trading/pnl/calculator_test.go
@@ -93,6 +93,8 @@ func (m *mockTradingRepo) UpdatePosition(p *domain.Position) error {
 	return nil
 }
 
+func (m *mockTradingRepo) CloseOpenPositions(symbol, side string) error { return nil }
+
 func (m *mockTradingRepo) SaveBalance(b domain.Balance) error { return nil }
 
 // mockTx delegates to repo so assertions see the same slices.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -206,6 +206,7 @@ func run(ctx context.Context, cfg *config.Config, log logger.LoggerInterface, ec
 		bfMarketSpecSvc,
 		cfg.Runtime.SellSizePercentage,
 	)
+	signalWorker.SetPositionCloser(repo)
 	strategyMonitor := adapterworker.NewStrategyMonitorWorker(log, &strategyGetter{strat: strat})
 	maintenanceWorker := adapterworker.NewMaintenanceWorker(log, repo, cfg.DataRetention.RetentionDays, repo)
 


### PR DESCRIPTION
## Problem

When a stop-loss triggers but the actual exchange balance is below the minimum lot size (dust), the SELL order is correctly skipped. However the DB continues to hold `PARTIAL` positions with `remaining_size > 0`, causing stop-loss to fire silently on every tick with no effect.

**Observed on VPS:** XRP_JPY (actual balance: 0.067 XRP, lot size: 1 XRP) and ETH_JPY (actual: 0.0097 ETH, lot size: 0.01 ETH) — stop-loss injected 1,000+ SELL signals since deploy, all skipped, DB unchanged.

## Root Cause

`SignalWorker.processSignal` skips the SELL order when `getAvailableSellSize` returns 0 (balance below lot size), but does nothing to clean up the stale `PARTIAL` positions in the DB.

## Fix

When a `stop_loss` SELL is skipped due to no sellable balance, call `CloseOpenPositions(symbol, "BUY")` to mark the ghost positions `CLOSED` immediately, stopping the stop-loss loop.

### Changes

| File | Change |
|---|---|
| `domain/repository.go` | Add `CloseOpenPositions(symbol, side string) error` to `PositionRepository` |
| `persistence/position_repo.go` | Implement: `UPDATE … SET status='CLOSED' WHERE status IN ('OPEN','PARTIAL')` |
| `persistence/repository.go` | Delegate `CloseOpenPositions` |
| `adapter/worker/contracts.go` | Add `PositionCloser` interface |
| `adapter/worker/signal_worker.go` | Add `SetPositionCloser()`, `closeGhostPositions()` — called when stop-loss SELL skips due to dust |
| `pkg/engine/engine.go` | Wire `signalWorker.SetPositionCloser(repo)` |

## Tests Added

- `TestPositionRepository_CloseOpenPositions` — verifies only OPEN/PARTIAL positions for the target symbol+side are closed
- `TestProcessSignal_StopLossDust_ClosesGhostPositions` — verifies ghost positions are closed when stop-loss SELL is skipped due to dust balance
- `TestProcessSignal_NormalSell_DoesNotClosePositions` — verifies a regular SELL skip does not trigger ghost position cleanup