### PR TITLE
feat(strategy): implement take-profit price check on every tick

### DIFF
--- a/internal/adapter/worker/strategy_worker.go
+++ b/internal/adapter/worker/strategy_worker.go
@@ -326,6 +326,69 @@ func (w *StrategyWorker) getStopLossPct() float64 {
 	return 0
 }
 
+// checkTakeProfit returns a SELL signal when the current price has risen above the
+// take-profit threshold of any open BUY position for the symbol. Returns nil when
+// take-profit is not triggered or no position reader is configured.
+func (w *StrategyWorker) checkTakeProfit(symbol string, currentPrice float64) *strategy.Signal {
+	if w.positionReader == nil {
+		return nil
+	}
+
+	takeProfitPct := w.getTakeProfitPct()
+	if takeProfitPct <= 0 {
+		return nil
+	}
+
+	positions, err := w.positionReader.GetOpenPositions(symbol, "BUY")
+	if err != nil {
+		w.logger.Strategy().WithError(err).Warn("Failed to read open positions for take-profit check")
+		return nil
+	}
+
+	for i := range positions {
+		pos := &positions[i]
+		if pos.EntryPrice <= 0 {
+			continue
+		}
+		takePrice := pos.EntryPrice * (1.0 + takeProfitPct/100.0)
+		if currentPrice >= takePrice {
+			w.logger.Trading().
+				WithField("symbol", symbol).
+				WithField("entry_price", pos.EntryPrice).
+				WithField("current_price", currentPrice).
+				WithField("take_price", takePrice).
+				WithField("take_profit_pct", takeProfitPct).
+				Info("Take profit triggered — injecting SELL signal")
+			return &strategy.Signal{
+				Symbol:    symbol,
+				Action:    strategy.SignalSell,
+				Strength:  1.0,
+				Price:     currentPrice,
+				Timestamp: time.Now(),
+				Metadata: map[string]interface{}{
+					"reason":          "take_profit",
+					"entry_price":     pos.EntryPrice,
+					"take_price":      takePrice,
+					"take_profit_pct": takeProfitPct,
+				},
+			}
+		}
+	}
+	return nil
+}
+
+// getTakeProfitPct reads take_profit_pct from the strategy configuration.
+// Returns 0 when not configured or invalid.
+func (w *StrategyWorker) getTakeProfitPct() float64 {
+	if w.strategy == nil {
+		return 0
+	}
+	if v, ok := asFloat(w.strategy.GetConfig()["take_profit_pct"]); ok && v > 0 {
+		return v
+	}
+	return 0
+}
+
 // executeStrategy executes the strategy
 func (w *StrategyWorker) executeStrategy(ctx context.Context, marketData *domain.MarketData, history []strategy.MarketData) {
 	// History already includes the latest data, use as is
@@ -350,12 +413,14 @@ func (w *StrategyWorker) executeStrategy(ctx context.Context, marketData *domain
 	// Reduce log volume for high-frequency market data
 	logEntry.Debug("Strategy analysis completed")
 
-	// Stop-loss override: if an open BUY position has breached its stop price,
-	// inject a SELL regardless of the EMA signal. This runs even when the
-	// strategy says HOLD or BUY, ensuring positions are cut quickly.
+	// Stop-loss / take-profit override: inject a SELL regardless of the EMA signal
+	// when an open BUY position has breached its stop or take-profit price.
+	// Stop-loss is checked first (risk priority); take-profit only when no SL fires.
 	if signal.Action != strategy.SignalSell {
 		if slSignal := w.checkStopLoss(marketData.Symbol, marketData.Price); slSignal != nil {
 			signal = slSignal
+		} else if tpSignal := w.checkTakeProfit(marketData.Symbol, marketData.Price); tpSignal != nil {
+			signal = tpSignal
 		}
 	}
 

--- a/internal/adapter/worker/take_profit_test.go
+++ b/internal/adapter/worker/take_profit_test.go
@@ -1,0 +1,133 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/bmf-san/gogocoin/internal/domain"
+	strategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+func TestCheckTakeProfit_NoPositionReader(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 2.0})
+	// No position reader set — must return nil
+	if got := w.checkTakeProfit("ETH_JPY", 340000.0); got != nil {
+		t.Fatalf("expected nil when no position reader, got %+v", got)
+	}
+}
+
+func TestCheckTakeProfit_NoOpenPositions(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 2.0})
+	w.SetPositionReader(&mockPositionReader{positions: []domain.Position{}})
+
+	if got := w.checkTakeProfit("ETH_JPY", 340000.0); got != nil {
+		t.Fatalf("expected nil for empty positions, got %+v", got)
+	}
+}
+
+func TestCheckTakeProfit_NotTriggered(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 2.0})
+	w.SetPositionReader(&mockPositionReader{
+		positions: []domain.Position{
+			{Symbol: "ETH_JPY", Side: "BUY", EntryPrice: 330000.0, Status: "OPEN"},
+		},
+	})
+
+	// 2% above 330000 = 336600; current price 335000 is below TP → no trigger
+	if got := w.checkTakeProfit("ETH_JPY", 335000.0); got != nil {
+		t.Fatalf("take profit should not trigger at 335000 (tp=336600), got %+v", got)
+	}
+}
+
+func TestCheckTakeProfit_Triggered(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 2.0})
+	w.SetPositionReader(&mockPositionReader{
+		positions: []domain.Position{
+			{Symbol: "ETH_JPY", Side: "BUY", EntryPrice: 330000.0, Status: "OPEN"},
+		},
+	})
+
+	// 2% above 330000 = 336600; current price 340000 is above TP → trigger
+	got := w.checkTakeProfit("ETH_JPY", 340000.0)
+	if got == nil {
+		t.Fatal("expected SELL signal when take profit triggers, got nil")
+	}
+	if got.Action != strategy.SignalSell {
+		t.Fatalf("expected SignalSell, got %v", got.Action)
+	}
+	if got.Symbol != "ETH_JPY" {
+		t.Fatalf("expected symbol ETH_JPY, got %v", got.Symbol)
+	}
+	if got.Metadata["reason"] != "take_profit" {
+		t.Fatalf("expected reason=take_profit, got %v", got.Metadata["reason"])
+	}
+}
+
+func TestCheckTakeProfit_ExactlyAtTakePrice(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 2.0})
+	w.SetPositionReader(&mockPositionReader{
+		positions: []domain.Position{
+			{Symbol: "ETH_JPY", Side: "BUY", EntryPrice: 330000.0, Status: "OPEN"},
+		},
+	})
+
+	// exactly at take price (330000 * 1.02 = 336600) must trigger
+	got := w.checkTakeProfit("ETH_JPY", 336600.0)
+	if got == nil {
+		t.Fatal("expected SELL signal at exact take price, got nil")
+	}
+}
+
+func TestCheckTakeProfit_ZeroTakeProfitPct(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 0.0})
+	w.SetPositionReader(&mockPositionReader{
+		positions: []domain.Position{
+			{Symbol: "ETH_JPY", Side: "BUY", EntryPrice: 330000.0, Status: "OPEN"},
+		},
+	})
+
+	// take_profit_pct=0 means disabled
+	if got := w.checkTakeProfit("ETH_JPY", 999999.0); got != nil {
+		t.Fatalf("take profit should be disabled when pct=0, got %+v", got)
+	}
+}
+
+func TestCheckTakeProfit_PartialPosition_Triggered(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 2.0})
+	w.SetPositionReader(&mockPositionReader{
+		positions: []domain.Position{
+			{Symbol: "ETH_JPY", Side: "BUY", EntryPrice: 330792.0, Status: "PARTIAL"},
+		},
+	})
+
+	// 2% above 330792 = 337407.84; current price 340362 is above TP → trigger
+	got := w.checkTakeProfit("ETH_JPY", 340362.0)
+	if got == nil {
+		t.Fatal("expected SELL signal for PARTIAL position above take price, got nil")
+	}
+	if got.Action != strategy.SignalSell {
+		t.Fatalf("expected SignalSell, got %v", got.Action)
+	}
+	if got.Metadata["reason"] != "take_profit" {
+		t.Fatalf("expected reason=take_profit, got %v", got.Metadata["reason"])
+	}
+}
+
+func TestCheckTakeProfit_MultiplePositions_FirstTriggered(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 2.0})
+	w.SetPositionReader(&mockPositionReader{
+		positions: []domain.Position{
+			{Symbol: "ETH_JPY", Side: "BUY", EntryPrice: 330000.0, Status: "OPEN"}, // tp 336600
+			{Symbol: "ETH_JPY", Side: "BUY", EntryPrice: 335000.0, Status: "OPEN"}, // tp 341700
+		},
+	})
+
+	// 340000 > 336600 (first) but < 341700 (second) → triggers on first position
+	got := w.checkTakeProfit("ETH_JPY", 340000.0)
+	if got == nil {
+		t.Fatal("expected SELL signal, got nil")
+	}
+	entryPrice, _ := got.Metadata["entry_price"].(float64)
+	if entryPrice != 330000.0 {
+		t.Fatalf("expected entry_price=330000.0, got %v", entryPrice)
+	}
+}


### PR DESCRIPTION
## Problem

`take_profit_pct` was present in the config but had no enforcement logic.
Positions were held until an EMA crossover occurred, so the take-profit condition
(price ≥ entry × (1 + TP%)) was never acted on automatically.

## Solution

Implement `checkTakeProfit()` in `StrategyWorker`, mirroring the existing `checkStopLoss()` mechanism.
On every market-data tick, open BUY positions are checked against the take-profit threshold.
When the condition is met, a SELL signal is injected immediately regardless of EMA state.

## Changes

### `internal/adapter/worker/strategy_worker.go`
- Add `checkTakeProfit(symbol string, currentPrice float64) *strategy.Signal`
  - Reads open BUY positions via `positionReader`
  - Returns a SELL signal when `currentPrice >= entry_price * (1 + take_profit_pct/100)`
  - Metadata: `reason=take_profit`, `entry_price`, `take_price`, `take_profit_pct`
- Add `getTakeProfitPct() float64` helper (reads `take_profit_pct` from strategy config)
- Wire into `executeStrategy()`: stop-loss is checked first (risk priority); take-profit only runs when no SL fires

### `internal/adapter/worker/take_profit_test.go` (new)
8 test cases:
- No position reader → nil
- No open positions → nil
- Price below TP threshold → nil
- Price above TP threshold → SELL signal
- Price exactly at TP threshold → SELL signal
- `take_profit_pct=0` → disabled
- PARTIAL position above TP → SELL signal
- Multiple positions, only first breached → SELL signal with correct entry price

## Test Results

```
--- PASS: TestCheckTakeProfit_NoPositionReader
--- PASS: TestCheckTakeProfit_NoOpenPositions
--- PASS: TestCheckTakeProfit_NotTriggered
--- PASS: TestCheckTakeProfit_Triggered
--- PASS: TestCheckTakeProfit_ExactlyAtTakePrice
--- PASS: TestCheckTakeProfit_ZeroTakeProfitPct
--- PASS: TestCheckTakeProfit_PartialPosition_Triggered
--- PASS: TestCheckTakeProfit_MultiplePositions_FirstTriggered
PASS (11 tests including stop-loss suite)
```