### PR TITLE
fix(worker): close ghost positions when take-profit SELL skips due to dust

### DIFF
--- a/internal/adapter/worker/signal_worker.go
+++ b/internal/adapter/worker/signal_worker.go
@@ -151,11 +151,11 @@ func (w *SignalWorker) processSignal(ctx context.Context, signal *strategy.Signa
 	// Create order (pass context for balance checking)
 	order, skip := w.createOrderFromSignal(ctx, signal)
 	if skip {
-		// If a stop-loss SELL was skipped because the exchange balance is dust
-		// (below the minimum lot size), close the ghost PARTIAL positions in the
-		// DB so stop-loss stops firing on already-liquidated positions.
+		// If a stop-loss or take-profit SELL was skipped because the exchange
+		// balance is dust (below the minimum lot size), close the ghost PARTIAL
+		// positions in the DB so the condition stops firing on every tick.
 		if signal.Action == strategy.SignalSell {
-			if reason, ok := signal.Metadata["reason"].(string); ok && reason == "stop_loss" {
+			if reason, ok := signal.Metadata["reason"].(string); ok && (reason == "stop_loss" || reason == "take_profit") {
 				w.closeGhostPositions(signal.Symbol)
 			}
 		}


### PR DESCRIPTION
## Problem

`closeGhostPositions()` was only called when `reason == "stop_loss"`.
When a take-profit SELL was skipped due to dust balance (below the minimum lot size),
PARTIAL positions remained open in the DB, causing take-profit to re-fire on every tick.

## Fix

Extend the ghost-position cleanup to cover both `stop_loss` and `take_profit` reasons.

```go
// Before
if reason == "stop_loss" {
    w.closeGhostPositions(signal.Symbol)
}

// After
if reason == "stop_loss" || reason == "take_profit" {
    w.closeGhostPositions(signal.Symbol)
}
```