### PR TITLE
fix(worker): bypass EMA dedup for stop-loss and take-profit signals

### DIFF
--- a/internal/adapter/worker/forced_exit_dedup_test.go
+++ b/internal/adapter/worker/forced_exit_dedup_test.go
@@ -1,0 +1,165 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bmf-san/gogocoin/internal/domain"
+	strategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+// mockStrategyHold always returns a HOLD signal so the SL/TP override is
+// exercised exclusively by the tests in this file.
+type mockStrategyHold struct {
+	mockStrategyWithConfig
+}
+
+func (m *mockStrategyHold) Analyze(data []strategy.MarketData) (*strategy.Signal, error) {
+	sym := ""
+	if len(data) > 0 {
+		sym = data[0].Symbol
+	}
+	return &strategy.Signal{Symbol: sym, Action: strategy.SignalHold}, nil
+}
+
+// newForcedExitWorker builds a StrategyWorker whose EMA always returns HOLD,
+// so only SL/TP can inject a SELL into signalCh.
+func newForcedExitWorker(t *testing.T, cfg map[string]any, positions []domain.Position) (*StrategyWorker, chan *strategy.Signal) {
+	t.Helper()
+	w := newTestStrategyWorker(t, cfg)
+	// Replace the strategy with the HOLD-only variant
+	w.strategy = &mockStrategyHold{mockStrategyWithConfig: mockStrategyWithConfig{cfg: cfg}}
+	w.SetPositionReader(&mockPositionReader{positions: positions})
+	// Replace signalCh with a buffered channel for assertions
+	signalCh := make(chan *strategy.Signal, 20)
+	w.signalCh = signalCh
+	return w, signalCh
+}
+
+// callExecuteStrategy invokes executeStrategy with a single synthetic market data
+// point at the given price.
+func callExecuteStrategy(w *StrategyWorker, symbol string, price float64) {
+	data := &domain.MarketData{Symbol: symbol, Price: price}
+	history := []strategy.MarketData{{Symbol: symbol, Price: price}}
+	w.executeStrategy(context.Background(), data, history)
+}
+
+// --- Stop-loss dedup bypass ---
+
+// TestForcedExit_StopLossBypassesDedupAfterEmaSell confirms that a stop-loss SELL
+// is dispatched to signalCh even when a previous EMA SELL already set
+// lastSentSignals[symbol]=SELL (which would normally suppress the signal).
+func TestForcedExit_StopLossBypassesDedupAfterEmaSell(t *testing.T) {
+	const symbol = "XRP_JPY"
+	positions := []domain.Position{
+		{Symbol: symbol, Side: "BUY", EntryPrice: 230.0, Status: "PARTIAL"},
+	}
+	w, signalCh := newForcedExitWorker(t, map[string]any{"stop_loss_pct": 1.5}, positions)
+
+	// Simulate a stale EMA SELL that set lastSentSignals without closing the position.
+	w.lastSentSignals.Store(symbol, strategy.SignalSell)
+
+	// Current price is below stop (230 * 0.985 = 226.55); stop-loss must override dedup.
+	callExecuteStrategy(w, symbol, 224.0)
+
+	select {
+	case sig := <-signalCh:
+		if sig.Action != strategy.SignalSell {
+			t.Fatalf("expected SELL, got %v", sig.Action)
+		}
+		if sig.Metadata["reason"] != "stop_loss" {
+			t.Fatalf("expected reason=stop_loss, got %v", sig.Metadata["reason"])
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("stop-loss SELL should bypass stale EMA dedup but no signal received")
+	}
+}
+
+// TestForcedExit_TakeProfitBypassesDedupAfterEmaSell confirms that a take-profit
+// SELL is dispatched after a stale EMA SELL set lastSentSignals.
+func TestForcedExit_TakeProfitBypassesDedupAfterEmaSell(t *testing.T) {
+	const symbol = "ETH_JPY"
+	positions := []domain.Position{
+		{Symbol: symbol, Side: "BUY", EntryPrice: 330000.0, Status: "OPEN"},
+	}
+	w, signalCh := newForcedExitWorker(t, map[string]any{"take_profit_pct": 3.0}, positions)
+
+	w.lastSentSignals.Store(symbol, strategy.SignalSell)
+
+	// 3% above 330000 = 339900; current 340000 triggers TP.
+	callExecuteStrategy(w, symbol, 340000.0)
+
+	select {
+	case sig := <-signalCh:
+		if sig.Action != strategy.SignalSell {
+			t.Fatalf("expected SELL, got %v", sig.Action)
+		}
+		if sig.Metadata["reason"] != "take_profit" {
+			t.Fatalf("expected reason=take_profit, got %v", sig.Metadata["reason"])
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("take-profit SELL should bypass stale EMA dedup but no signal received")
+	}
+}
+
+// --- Cooldown enforcement ---
+
+// TestForcedExit_CooldownBlocksRepeat confirms that a second forced exit for the
+// same symbol within the cooldown window is suppressed (no duplicate order).
+func TestForcedExit_CooldownBlocksRepeat(t *testing.T) {
+	const symbol = "XRP_JPY"
+	positions := []domain.Position{
+		{Symbol: symbol, Side: "BUY", EntryPrice: 230.0, Status: "PARTIAL"},
+	}
+	w, signalCh := newForcedExitWorker(t, map[string]any{"stop_loss_pct": 1.5}, positions)
+
+	// First call — should enqueue the SELL.
+	callExecuteStrategy(w, symbol, 224.0)
+
+	select {
+	case sig := <-signalCh:
+		if sig.Action != strategy.SignalSell {
+			t.Fatalf("first call: expected SELL, got %v", sig.Action)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("first stop-loss SELL should have been enqueued")
+	}
+
+	// Second call immediately — must be suppressed by cooldown.
+	callExecuteStrategy(w, symbol, 224.0)
+
+	select {
+	case sig := <-signalCh:
+		t.Fatalf("second call within cooldown should be suppressed, got %v", sig)
+	case <-time.After(50 * time.Millisecond):
+		// expected: no signal
+	}
+}
+
+// TestForcedExit_CooldownExpiredAllowsRetry confirms that a forced exit IS
+// re-sent after the cooldown window has elapsed.
+func TestForcedExit_CooldownExpiredAllowsRetry(t *testing.T) {
+	const symbol = "XRP_JPY"
+	positions := []domain.Position{
+		{Symbol: symbol, Side: "BUY", EntryPrice: 230.0, Status: "PARTIAL"},
+	}
+	w, signalCh := newForcedExitWorker(t, map[string]any{"stop_loss_pct": 1.5}, positions)
+
+	// Simulate a forced exit that happened far in the past (beyond cooldown).
+	pastTime := time.Now().Add(-(ForcedExitCooldown + time.Second))
+	w.lastForcedExitAttempt.Store(symbol, pastTime)
+	// Also set lastSentSignals=SELL to confirm the dedup is bypassed.
+	w.lastSentSignals.Store(symbol, strategy.SignalSell)
+
+	callExecuteStrategy(w, symbol, 224.0)
+
+	select {
+	case sig := <-signalCh:
+		if sig.Action != strategy.SignalSell {
+			t.Fatalf("expected SELL after cooldown expired, got %v", sig.Action)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("stop-loss SELL should fire after cooldown expired but no signal received")
+	}
+}

--- a/internal/adapter/worker/strategy_worker.go
+++ b/internal/adapter/worker/strategy_worker.go
@@ -21,6 +21,11 @@ const (
 	// DefaultMaxConcurrentProcessing is the default maximum number of concurrent market data processing goroutines
 	// This prevents memory exhaustion from unbounded goroutine creation during high-frequency market data
 	DefaultMaxConcurrentProcessing = 10
+
+	// ForcedExitCooldown is the minimum interval between successive forced-exit
+	// (stop-loss / take-profit) SELL signals for the same symbol. This prevents
+	// duplicate orders while still retrying if the first attempt failed.
+	ForcedExitCooldown = 30 * time.Second
 )
 
 // symbolHistory holds market data history for a single symbol with its own lock
@@ -52,6 +57,11 @@ type StrategyWorker struct {
 	// Deduplication: track last sent signal action per symbol to avoid flooding the channel
 	// with identical signals on every tick during a sustained trend
 	lastSentSignals sync.Map // map[string]strategy.SignalAction
+
+	// lastForcedExitAttempt tracks when a forced-exit (SL/TP) SELL was last dispatched
+	// per symbol so that repeated attempts are gated by ForcedExitCooldown rather than
+	// the standard action-level dedup (which would block them indefinitely after any EMA SELL).
+	lastForcedExitAttempt sync.Map // map[string]time.Time
 
 	// positionReader is optional; when set, stop-loss is checked on every tick.
 	positionReader PositionReader
@@ -416,20 +426,38 @@ func (w *StrategyWorker) executeStrategy(ctx context.Context, marketData *domain
 	// Stop-loss / take-profit override: inject a SELL regardless of the EMA signal
 	// when an open BUY position has breached its stop or take-profit price.
 	// Stop-loss is checked first (risk priority); take-profit only when no SL fires.
+	isForcedExit := false
 	if signal.Action != strategy.SignalSell {
 		if slSignal := w.checkStopLoss(marketData.Symbol, marketData.Price); slSignal != nil {
 			signal = slSignal
+			isForcedExit = true
 		} else if tpSignal := w.checkTakeProfit(marketData.Symbol, marketData.Price); tpSignal != nil {
 			signal = tpSignal
+			isForcedExit = true
 		}
 	}
 
 	if signal.Action != strategy.SignalHold {
-		// Deduplicate: skip if the action is the same as the last sent signal for this symbol.
-		// Once a SELL/BUY trend is established, every tick would re-generate the same signal;
-		// we only need to act on the transition (e.g., HOLD→SELL or BUY→SELL).
-		if last, ok := w.lastSentSignals.Load(signal.Symbol); ok && last.(strategy.SignalAction) == signal.Action {
-			return
+		if isForcedExit {
+			// Forced exits (SL/TP) bypass the standard action-level dedup because a prior
+			// EMA SELL sets lastSentSignals=SELL and would block all subsequent SL/TP signals
+			// indefinitely. Instead, use a separate per-symbol cooldown so we retry after
+			// ForcedExitCooldown without hammering the exchange on every tick.
+			if last, ok := w.lastForcedExitAttempt.Load(signal.Symbol); ok {
+				if time.Since(last.(time.Time)) < ForcedExitCooldown {
+					return // still within cooldown — wait for prior order to settle
+				}
+			}
+			// Cooldown elapsed (or first attempt): clear standard dedup so the SELL is not
+			// blocked by a stale EMA-generated SELL recorded in lastSentSignals.
+			w.lastSentSignals.Delete(signal.Symbol)
+		} else {
+			// Standard EMA dedup: skip if the action is the same as the last sent signal.
+			// Once a SELL/BUY trend is established, every tick would re-generate the same
+			// signal; we only need to act on the transition (e.g., HOLD→SELL or BUY→SELL).
+			if last, ok := w.lastSentSignals.Load(signal.Symbol); ok && last.(strategy.SignalAction) == signal.Action {
+				return
+			}
 		}
 
 		// Only log actual trading signals (not HOLD signals) to reduce log volume
@@ -446,6 +474,9 @@ func (w *StrategyWorker) executeStrategy(ctx context.Context, marketData *domain
 		case w.signalCh <- signal:
 			// Record last sent action only on successful send
 			w.lastSentSignals.Store(signal.Symbol, signal.Action)
+			if isForcedExit {
+				w.lastForcedExitAttempt.Store(signal.Symbol, time.Now())
+			}
 		case <-ctx.Done():
 			return
 		default:

--- a/internal/usecase/risk/manager_test.go
+++ b/internal/usecase/risk/manager_test.go
@@ -118,7 +118,12 @@ func TestCheckDailyTradeLimit(t *testing.T) {
 		MaxDailyTrades: 5,
 	}
 
-	now := time.Now()
+	// Anchor trade timestamps to today's JST midnight so the test is stable
+	// regardless of what time of day it runs (relative offsets like -5h can
+	// cross midnight and land on the previous day).
+	jst, _ := time.LoadLocation("Asia/Tokyo")
+	today := time.Now().In(jst)
+	todayJST := time.Date(today.Year(), today.Month(), today.Day(), 0, 1, 0, 0, jst)
 
 	tests := []struct {
 		name        string
@@ -128,27 +133,27 @@ func TestCheckDailyTradeLimit(t *testing.T) {
 		{
 			name: "Under daily limit",
 			trades: []domain.Trade{
-				{CreatedAt: now.Add(-1 * time.Hour)},
-				{CreatedAt: now.Add(-2 * time.Hour)},
+				{CreatedAt: todayJST.Add(1 * time.Minute)},
+				{CreatedAt: todayJST.Add(2 * time.Minute)},
 			},
 			expectError: false,
 		},
 		{
 			name: "At daily limit",
 			trades: []domain.Trade{
-				{CreatedAt: now.Add(-1 * time.Hour)},
-				{CreatedAt: now.Add(-2 * time.Hour)},
-				{CreatedAt: now.Add(-3 * time.Hour)},
-				{CreatedAt: now.Add(-4 * time.Hour)},
-				{CreatedAt: now.Add(-5 * time.Hour)},
+				{CreatedAt: todayJST.Add(1 * time.Minute)},
+				{CreatedAt: todayJST.Add(2 * time.Minute)},
+				{CreatedAt: todayJST.Add(3 * time.Minute)},
+				{CreatedAt: todayJST.Add(4 * time.Minute)},
+				{CreatedAt: todayJST.Add(5 * time.Minute)},
 			},
 			expectError: true,
 		},
 		{
 			name: "No trades today",
 			trades: []domain.Trade{
-				{CreatedAt: now.Add(-25 * time.Hour)},
-				{CreatedAt: now.Add(-26 * time.Hour)},
+				{CreatedAt: todayJST.Add(-25 * time.Hour)},
+				{CreatedAt: todayJST.Add(-26 * time.Hour)},
 			},
 			expectError: false,
 		},
@@ -282,6 +287,9 @@ func TestCheckRiskManagement(t *testing.T) {
 	}
 
 	now := time.Now()
+	jst, _ := time.LoadLocation("Asia/Tokyo")
+	todayInJST := now.In(jst)
+	todayJST := time.Date(todayInJST.Year(), todayInJST.Month(), todayInJST.Day(), 0, 1, 0, 0, jst)
 
 	tests := []struct {
 		name        string
@@ -326,11 +334,11 @@ func TestCheckRiskManagement(t *testing.T) {
 			},
 			balances: []domain.Balance{{Currency: "JPY", Available: 100000}},
 			trades: []domain.Trade{
-				{CreatedAt: now.Add(-1 * time.Hour), ExecutedAt: now.Add(-1 * time.Hour)},
-				{CreatedAt: now.Add(-2 * time.Hour), ExecutedAt: now.Add(-2 * time.Hour)},
-				{CreatedAt: now.Add(-3 * time.Hour), ExecutedAt: now.Add(-3 * time.Hour)},
-				{CreatedAt: now.Add(-4 * time.Hour), ExecutedAt: now.Add(-4 * time.Hour)},
-				{CreatedAt: now.Add(-5 * time.Hour), ExecutedAt: now.Add(-5 * time.Hour)},
+				{CreatedAt: todayJST.Add(1 * time.Minute), ExecutedAt: todayJST.Add(1 * time.Minute)},
+				{CreatedAt: todayJST.Add(2 * time.Minute), ExecutedAt: todayJST.Add(2 * time.Minute)},
+				{CreatedAt: todayJST.Add(3 * time.Minute), ExecutedAt: todayJST.Add(3 * time.Minute)},
+				{CreatedAt: todayJST.Add(4 * time.Minute), ExecutedAt: todayJST.Add(4 * time.Minute)},
+				{CreatedAt: todayJST.Add(5 * time.Minute), ExecutedAt: todayJST.Add(5 * time.Minute)},
 			},
 			metrics:     []domain.PerformanceMetric{},
 			expectError: true,


### PR DESCRIPTION
## Problem

The action-level deduplication in `executeStrategy` (`lastSentSignals`) tracks the last signal action sent per symbol. When an EMA crossover generates a SELL signal, it sets `lastSentSignals[symbol] = SELL`. Any stop-loss or take-profit SELL that fires afterwards is then **permanently suppressed** by the dedup check:

```
// last = SELL (from prior EMA), current = SELL (from SL) → dedup blocks forever
if last == signal.Action { return }
```

The symptom is an infinite stream of WARN logs:
```
Stop loss triggered — injecting SELL signal  (fires every 0.5s)
```
…but **no order is ever placed**, because the signal never reaches `signal_worker`.

## Root cause trace (live incident)

- `XRP_JPY` position open at entry 230.68 (created 2026-03-23 23:59)  
- EMA SELL at 00:33 → `lastSentSignals[XRP_JPY] = SELL`  
- Price drops to 222.6 (below stop 227.22) at 00:57  
- Stop-loss WARN fires every tick; dedup blocks all sends → no SELL order ever placed  
- Same pattern observed for `ETH_JPY`

## Fix

Introduce a **separate per-symbol cooldown** (`ForcedExitCooldown = 30 s`) for forced exits (SL/TP):

- First forced-exit SELL **always** bypasses the EMA dedup by deleting the stale `lastSentSignals` entry before sending.  
- Subsequent ticks within the 30 s window are suppressed (respects `lastForcedExitAttempt`), preventing duplicate/flood orders.  
- After 30 s, a retry is allowed — handles API failures or partial fills that left the position open.  
- Normal EMA-based dedup is entirely unaffected.

## Tests added (`forced_exit_dedup_test.go`)

| Test | Scenario |
|------|----------|
| `TestForcedExit_StopLossBypassesDedupAfterEmaSell` | SL fires after EMA SELL set dedup → SELL must be dispatched |
| `TestForcedExit_TakeProfitBypassesDedupAfterEmaSell` | TP fires after EMA SELL set dedup → SELL must be dispatched |
| `TestForcedExit_CooldownBlocksRepeat` | Second SL within 30 s is suppressed (no duplicate order) |
| `TestForcedExit_CooldownExpiredAllowsRetry` | SL retries after 30 s cooldown expires |