### PR TITLE
fix(risk): bypass portfolio-protection checks for stop-loss/take-profit SELL

### DIFF
--- a/internal/usecase/risk/manager.go
+++ b/internal/usecase/risk/manager.go
@@ -58,6 +58,18 @@ func NewRiskManager(
 	}
 }
 
+// isForcedExitSell reports whether signal is a SELL triggered by stop-loss or
+// take-profit.  These signals exist to limit further losses, so blocking them
+// via portfolio-protection checks (daily limit, trade interval, total loss
+// limit) would be counter-productive.
+func isForcedExitSell(signal *strategy.Signal) bool {
+	if signal.Action != strategy.SignalSell {
+		return false
+	}
+	reason, _ := signal.Metadata["reason"].(string)
+	return reason == "stop_loss" || reason == "take_profit"
+}
+
 // CheckRiskManagement performs all risk management checks before placing an order
 // Returns error if any risk rule is violated
 func (rm *Manager) CheckRiskManagement(ctx context.Context, signal *strategy.Signal) error {
@@ -86,6 +98,19 @@ func (rm *Manager) CheckRiskManagement(ctx context.Context, signal *strategy.Sig
 		if err := rm.checkTradeAmount(signal, totalBalanceJPY); err != nil {
 			return fmt.Errorf("trade amount validation failed: %w", err)
 		}
+	}
+
+	// Forced exits (stop-loss / take-profit SELLs) bypass portfolio-protection
+	// checks.  These checks exist to prevent reckless over-trading, but blocking
+	// an emergency exit makes losses worse, not better.
+	if isForcedExitSell(signal) {
+		if rm.logger != nil {
+			rm.logger.System().Info("Bypassing portfolio checks for forced exit SELL",
+				"symbol", signal.Symbol,
+				"reason", signal.Metadata["reason"],
+			)
+		}
+		return nil
 	}
 
 	// Check daily trade limit

--- a/internal/usecase/risk/manager_test.go
+++ b/internal/usecase/risk/manager_test.go
@@ -377,3 +377,88 @@ func TestCheckRiskManagement(t *testing.T) {
 		})
 	}
 }
+
+// TestForcedExitSellBypassesPortfolioChecks verifies that stop-loss and
+// take-profit SELL signals are allowed even when portfolio-protection checks
+// (daily trade limit, trade interval, total loss limit) would otherwise block
+// the order.  Blocking an emergency exit makes a loss situation worse.
+func TestForcedExitSellBypassesPortfolioChecks(t *testing.T) {
+	cfg := ManagerConfig{
+		MaxTradeAmountPercent: 10.0,
+		MaxDailyTrades:        2,    // already exhausted
+		MinTradeInterval:      1 * time.Hour, // last trade was recent
+		MaxTotalLossPercent:   10.0, // already exceeded
+		FeeRate:               0.001,
+		InitialBalance:        100000,
+	}
+
+	jst, _ := time.LoadLocation("Asia/Tokyo")
+	todayInJST := time.Now().In(jst)
+	todayJST := time.Date(todayInJST.Year(), todayInJST.Month(), todayInJST.Day(), 0, 1, 0, 0, jst)
+
+	// Conditions that would block a normal SELL:
+	//   - daily limit reached (2 trades today)
+	//   - last trade 30s ago (< 1h interval)
+	//   - total loss 15% > 10% limit
+	blockedTrades := []domain.Trade{
+		{CreatedAt: todayJST.Add(1 * time.Minute), ExecutedAt: time.Now().Add(-30 * time.Second)},
+		{CreatedAt: todayJST.Add(2 * time.Minute), ExecutedAt: time.Now().Add(-30 * time.Second)},
+	}
+	blockedMetrics := []domain.PerformanceMetric{{TotalPnL: -15000}}
+	blockedBalances := []domain.Balance{
+		{Currency: "JPY", Available: 0},
+		{Currency: "BTC", Available: 0.001},
+	}
+
+	tests := []struct {
+		name        string
+		reason      string
+		expectError bool
+	}{
+		{
+			name:        "stop_loss SELL bypasses all checks",
+			reason:      "stop_loss",
+			expectError: false,
+		},
+		{
+			name:        "take_profit SELL bypasses all checks",
+			reason:      "take_profit",
+			expectError: false,
+		},
+		{
+			name:        "plain SELL (no reason) is still blocked",
+			reason:      "",
+			expectError: true,
+		},
+		{
+			name:        "SELL with unrelated reason is still blocked",
+			reason:      "ema_crossover",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signal := &strategy.Signal{
+				Action:   strategy.SignalSell,
+				Symbol:   "BTC_JPY",
+				Price:    5000000,
+				Quantity: 0.001,
+				Metadata: map[string]interface{}{},
+			}
+			if tt.reason != "" {
+				signal.Metadata["reason"] = tt.reason
+			}
+
+			tradingRepo := &mockTradingRepo{trades: blockedTrades}
+			analyticsRepo := &mockAnalyticsRepo{metrics: blockedMetrics}
+			trader := &mockTrader{balances: blockedBalances}
+			rm := NewRiskManager(cfg, tradingRepo, analyticsRepo, trader, nil)
+
+			err := rm.CheckRiskManagement(context.Background(), signal)
+			if (err != nil) != tt.expectError {
+				t.Errorf("CheckRiskManagement() reason=%q error = %v, expectError %v", tt.reason, err, tt.expectError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When total losses exceeded the configured threshold (`MaxTotalLossPercent`), **all** SELL orders were silently rejected by `CheckRiskManagement` — including emergency stop-loss and take-profit SELLs.

In production (v1.4.8), both ETH_JPY and XRP_JPY positions dropped below their stop-loss thresholds but could not be closed:

```
Risk management check failed - order rejected: total loss limit exceeded: 15.06% > 15.00%
```

Blocking forced exits achieves the *opposite* of risk management: the open position accumulates further loss instead of being unwound.

## Root Cause

`CheckRiskManagement` applied `checkDailyTradeLimit`, `checkTradeInterval`, and `checkTotalLossLimit` uniformly to every signal, regardless of type.

## Fix

Add `isForcedExitSell` helper that detects SELL signals carrying `metadata["reason"] == "stop_loss"` or `"take_profit"`.  When detected, `CheckRiskManagement` returns `nil` immediately after the BUY-only balance/amount checks, skipping all three portfolio-protection checks.

Normal SELL signals (no reason, or an unrelated reason) continue to go through the full check pipeline.

## Tests

`TestForcedExitSellBypassesPortfolioChecks` (4 sub-tests) verifies:
- `stop_loss` SELL is allowed despite exhausted daily limit, recent trade interval, and exceeded total-loss threshold
- `take_profit` SELL is allowed under the same conditions
- Plain SELL (no `reason`) is still blocked normally
- SELL with an unrelated reason (`ema_crossover`) is still blocked normally