### PR TITLE
fix(webui): system log display order corrected to newest-first

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -457,10 +457,7 @@ class GogocoinUI {
                 return;
             }
 
-            // Reverse to show newest first (slice to avoid mutating original)
-            const reversedLogs = logs.slice().reverse();
-
-            container.innerHTML = reversedLogs.map(log => {
+            container.innerHTML = logs.map(log => {
                 const levelClass = log.level.toLowerCase();
                 const levelColor = {
                     'debug': 'text-slate-500',


### PR DESCRIPTION
## Problem

The system log panel in the Web UI was displaying entries in oldest-first order despite appearing to show newest entries first.

## Root Cause

`GetRecentLogsWithFilters` in `log_repo.go` already returns rows `ORDER BY timestamp DESC` (newest first). However `script.js` was calling `logs.slice().reverse()` on the result, reversing it back to oldest-first.

## Fix

Remove the redundant `slice().reverse()` call and display the array as returned by the API.