### PR TITLE
fix: prevent position stacking via max_open_positions_per_symbol

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -33,6 +33,7 @@ trading:
     max_trade_amount_percent: 80.0
     max_daily_trades: 100
     min_trade_interval: 60s
+    max_open_positions_per_symbol: 1  # prevent position stacking (one BUY per symbol at a time)
     # Note: profit/loss targets are in strategy_params.scalping
 
 # Scalping Strategy

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,9 +69,10 @@ type RiskManagementConfig struct {
 	MaxTotalLossPercent   float64 `yaml:"max_total_loss_percent"`
 	MaxTradeLossPercent   float64 `yaml:"max_trade_loss_percent"`
 	MaxDailyLossPercent   float64 `yaml:"max_daily_loss_percent"`
-	MaxTradeAmountPercent float64 `yaml:"max_trade_amount_percent"`
-	MaxDailyTrades        int     `yaml:"max_daily_trades"`
-	MinTradeInterval      string  `yaml:"min_trade_interval"`
+	MaxTradeAmountPercent        float64 `yaml:"max_trade_amount_percent"`
+	MaxDailyTrades               int     `yaml:"max_daily_trades"`
+	MinTradeInterval             string  `yaml:"min_trade_interval"`
+	MaxOpenPositionsPerSymbol    int     `yaml:"max_open_positions_per_symbol"` // 0 = unlimited
 }
 
 // StrategyParams represents strategy-specific parameters

--- a/internal/usecase/risk/config.go
+++ b/internal/usecase/risk/config.go
@@ -6,12 +6,13 @@ import "time"
 // This is a usecase-layer struct, free from infrastructure/config dependency.
 type ManagerConfig struct {
 	// Risk management parameters (from RiskManagementConfig)
-	MaxTotalLossPercent   float64
-	MaxTradeLossPercent   float64
-	MaxDailyLossPercent   float64
-	MaxTradeAmountPercent float64
-	MaxDailyTrades        int
-	MinTradeInterval      time.Duration
+	MaxTotalLossPercent        float64
+	MaxTradeLossPercent        float64
+	MaxDailyLossPercent        float64
+	MaxTradeAmountPercent      float64
+	MaxDailyTrades             int
+	MinTradeInterval           time.Duration
+	MaxOpenPositionsPerSymbol  int // 0 = unlimited
 
 	// Trading parameters (from TradingConfig)
 	FeeRate        float64

--- a/internal/usecase/risk/manager.go
+++ b/internal/usecase/risk/manager.go
@@ -18,18 +18,28 @@ type RiskManager interface {
 	CheckRiskManagement(ctx context.Context, signal *strategy.Signal) error
 }
 
+// PositionRepository defines the DB operations needed to check open positions.
+type PositionRepository interface {
+	GetOpenPositions(symbol string, side string) ([]domain.Position, error)
+}
+
 // Manager provides risk management functionality for trading operations
 // Enforces trading limits, intervals, and loss protection rules
 type Manager struct {
 	cfg           ManagerConfig
 	tradingRepo   TradingRepository
 	analyticsRepo AnalyticsRepository
+	positionRepo  PositionRepository
 	trader        trading.Trader
 	logger        logger.LoggerInterface
 }
 
 // Verify Manager implements RiskManager interface at compile time
 var _ RiskManager = (*Manager)(nil)
+
+// SetPositionRepository injects an optional PositionRepository used to enforce
+// max_open_positions_per_symbol.  Must be called before trading starts.
+func (rm *Manager) SetPositionRepository(repo PositionRepository) { rm.positionRepo = repo }
 
 // TradingRepository defines database operations needed for risk checks
 type TradingRepository interface {
@@ -97,6 +107,9 @@ func (rm *Manager) CheckRiskManagement(ctx context.Context, signal *strategy.Sig
 		}
 		if err := rm.checkTradeAmount(signal, totalBalanceJPY); err != nil {
 			return fmt.Errorf("trade amount validation failed: %w", err)
+		}
+		if err := rm.checkMaxOpenPositions(signal.Symbol); err != nil {
+			return err
 		}
 	}
 
@@ -268,5 +281,26 @@ func (rm *Manager) checkTotalLossLimit(ctx context.Context) error {
 			lossPercent, maxLossPercent, totalLoss, totalAssets)
 	}
 
+	return nil
+}
+
+// checkMaxOpenPositions rejects a BUY when the symbol already has too many
+// open positions.  This prevents position stacking where multiple sequential
+// BUYs accumulate and then a single stop-loss SELL exits all of them at once,
+// multiplying the loss.
+func (rm *Manager) checkMaxOpenPositions(symbol string) error {
+	max := rm.cfg.MaxOpenPositionsPerSymbol
+	if max <= 0 || rm.positionRepo == nil {
+		return nil // feature disabled or repository not wired
+	}
+	positions, err := rm.positionRepo.GetOpenPositions(symbol, "BUY")
+	if err != nil {
+		// Non-fatal: if we can't read positions, allow the trade rather than
+		// blocking it on a transient DB error.
+		return nil
+	}
+	if len(positions) >= max {
+		return fmt.Errorf("max open positions reached for %s: %d/%d", symbol, len(positions), max)
+	}
 	return nil
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -160,17 +160,19 @@ func run(ctx context.Context, cfg *config.Config, log logger.LoggerInterface, ec
 	minInterval, _ := time.ParseDuration(cfg.Trading.RiskManagement.MinTradeInterval)
 	riskMgr := risk.NewRiskManager(
 		risk.ManagerConfig{
-			MaxTotalLossPercent:   cfg.Trading.RiskManagement.MaxTotalLossPercent,
-			MaxTradeLossPercent:   cfg.Trading.RiskManagement.MaxTradeLossPercent,
-			MaxDailyLossPercent:   cfg.Trading.RiskManagement.MaxDailyLossPercent,
-			MaxTradeAmountPercent: cfg.Trading.RiskManagement.MaxTradeAmountPercent,
-			MaxDailyTrades:        cfg.Trading.RiskManagement.MaxDailyTrades,
-			MinTradeInterval:      minInterval,
-			FeeRate:               cfg.Trading.FeeRate,
-			InitialBalance:        cfg.Trading.InitialBalance,
+			MaxTotalLossPercent:       cfg.Trading.RiskManagement.MaxTotalLossPercent,
+			MaxTradeLossPercent:       cfg.Trading.RiskManagement.MaxTradeLossPercent,
+			MaxDailyLossPercent:       cfg.Trading.RiskManagement.MaxDailyLossPercent,
+			MaxTradeAmountPercent:     cfg.Trading.RiskManagement.MaxTradeAmountPercent,
+			MaxDailyTrades:            cfg.Trading.RiskManagement.MaxDailyTrades,
+			MinTradeInterval:          minInterval,
+			MaxOpenPositionsPerSymbol: cfg.Trading.RiskManagement.MaxOpenPositionsPerSymbol,
+			FeeRate:                   cfg.Trading.FeeRate,
+			InitialBalance:            cfg.Trading.InitialBalance,
 		},
 		repo, repo, trader, log,
 	)
+	riskMgr.SetPositionRepository(repo)
 
 	// ── 7. Performance analytics ──────────────────────────────────────────────
 	perfAnalytics := analytics.NewPerformanceAnalytics(repo, repo, log, cfg.Trading.InitialBalance)


### PR DESCRIPTION
## Problem

Consecutive losses observed in [my-gogocoin #101](https://github.com/bmf-san/my-gogocoin/issues/101) and [#102](https://github.com/bmf-san/my-gogocoin/issues/102).

**Root cause: Position Stacking**

When EMA crossovers fire in rapid succession, additional BUY orders are placed while an existing open position is already held for the same symbol. When stop-loss triggers, all stacked positions are liquidated in a single SELL, multiplying the loss.

```
Example (2026-03-26 ETH_JPY):
15:16  BUY  @ 338,677  (0.02 ETH)
15:36  BUY  @ 338,797  (0.02 ETH)  ← second BUY stacked on top of open position
18:31  SELL @ 333,234  (0.04 ETH)  ← SL fired on combined size = -220 JPY (expected ~-103 JPY)
```

## Fix

When `risk_management.max_open_positions_per_symbol: 1` is set, any BUY signal is rejected if the symbol already has an open BUY position.

### Changed files

- **`internal/usecase/risk/config.go`**: add `MaxOpenPositionsPerSymbol int` field
- **`internal/usecase/risk/manager.go`**:
  - add `PositionRepository` interface
  - add `SetPositionRepository()` setter
  - add `checkMaxOpenPositions()` method
  - wire check into `CheckRiskManagement()` for BUY signals
- **`internal/config/config.go`**: add `max_open_positions_per_symbol` YAML field
- **`pkg/engine/engine.go`**: wire position repo + pass new config field to `ManagerConfig`
- **`configs/config.example.yaml`**: set `max_open_positions_per_symbol: 1` as default

## Configuration

```yaml
trading:
  risk_management:
    max_open_positions_per_symbol: 1  # 0 = unlimited (previous behaviour)
```

## Backward compatibility

- `max_open_positions_per_symbol: 0` (default) is unlimited — identical to previous behaviour
- When `positionRepo` is `nil` the check is skipped (nil-safe)