### PR TITLE
fix(worker): close ghost positions on any skipped SELL signal (v1.4.12)

### DIFF
--- a/internal/adapter/worker/signal_worker.go
+++ b/internal/adapter/worker/signal_worker.go
@@ -151,13 +151,12 @@ func (w *SignalWorker) processSignal(ctx context.Context, signal *strategy.Signa
 	// Create order (pass context for balance checking)
 	order, skip := w.createOrderFromSignal(ctx, signal)
 	if skip {
-		// If a stop-loss or take-profit SELL was skipped because the exchange
-		// balance is dust (below the minimum lot size), close the ghost PARTIAL
-		// positions in the DB so the condition stops firing on every tick.
+		// If a SELL was skipped because the exchange balance is dust (below the
+		// minimum lot size), close ghost OPEN/PARTIAL positions in the DB.
+		// This handles SL/TP triggers as well as EMA crossover signals when the
+		// position was manually closed on the exchange side.
 		if signal.Action == strategy.SignalSell {
-			if reason, ok := signal.Metadata["reason"].(string); ok && (reason == "stop_loss" || reason == "take_profit") {
-				w.closeGhostPositions(signal.Symbol)
-			}
+			w.closeGhostPositions(signal.Symbol)
 		}
 		return
 	}

--- a/internal/adapter/worker/signal_worker_test.go
+++ b/internal/adapter/worker/signal_worker_test.go
@@ -660,9 +660,10 @@ func TestProcessSignal_StopLossDust_ClosesGhostPositions(t *testing.T) {
 	}
 }
 
-func TestProcessSignal_NormalSell_DoesNotClosePositions(t *testing.T) {
-	// A regular (non-stop-loss) SELL skipped due to no balance must NOT
-	// trigger ghost position cleanup.
+func TestProcessSignal_NormalSell_ClosesGhostPositions(t *testing.T) {
+	// A regular (EMA crossover) SELL skipped due to no balance must ALSO
+	// trigger ghost position cleanup so manually-closed positions don't block
+	// future BUYs.
 	log := createTestLogger(t)
 	signalCh := make(chan *strategy.Signal, 1)
 
@@ -688,11 +689,11 @@ func TestProcessSignal_NormalSell_DoesNotClosePositions(t *testing.T) {
 		Symbol:   "XRP_JPY",
 		Action:   strategy.SignalSell,
 		Price:    222.64,
-		Metadata: map[string]interface{}{}, // no "reason" = normal SELL
+		Metadata: map[string]interface{}{}, // no "reason" = normal EMA SELL
 	}
 	w.processSignal(context.Background(), sig)
 
-	if len(closer.closed) != 0 {
-		t.Errorf("normal SELL skip must not close ghost positions, got %v", closer.closed)
+	if len(closer.closed) != 1 || closer.closed[0] != "XRP_JPY:BUY" {
+		t.Errorf("EMA SELL skip must close ghost positions for symbol, got %v", closer.closed)
 	}
 }


### PR DESCRIPTION
## Problem

When a position was manually closed on the BitFlyer exchange, the DB still had an `OPEN` record. If an **EMA crossover SELL** fired next (before SL/TP), the signal would be skipped (balance = 0) but `closeGhostPositions` was **not called** — leaving the stale DB entry.

With `max_open_positions_per_symbol: 1`, this permanently blocked new BUYs for the symbol.

Previously, `closeGhostPositions` was only called for `reason == "stop_loss" || reason == "take_profit"` skips.

## Fix

Remove the reason check — any SELL signal skipped due to zero exchange balance now triggers ghost cleanup, regardless of whether it originated from SL/TP or an EMA crossover.

```go
// Before
if reason == "stop_loss" || reason == "take_profit" {
    w.closeGhostPositions(signal.Symbol)
}

// After — covers all SELL signals including EMA crossover
w.closeGhostPositions(signal.Symbol)
```

## Tests

- Updated `TestProcessSignal_NormalSell_DoesNotClosePositions` → renamed to `TestProcessSignal_NormalSell_ClosesGhostPositions` with correct assertion
- All existing tests pass