### PR TITLE
feat(strategy): add trend EMA filter to suppress BUY signals in downtrends (v1.4.13)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,9 @@ type StrategyParams struct {
 type ScalpingParams struct {
 	EMAFastPeriod  int     `yaml:"ema_fast_period"`
 	EMASlowPeriod  int     `yaml:"ema_slow_period"`
+	// TrendEMAPeriod is the long-term EMA used as a trend direction filter.
+	// BUY signals are suppressed when price < EMA(TrendEMAPeriod). 0 = disabled.
+	TrendEMAPeriod int     `yaml:"trend_ema_period"`
 	TakeProfitPct  float64 `yaml:"take_profit_pct"`
 	StopLossPct    float64 `yaml:"stop_loss_pct"`
 	CooldownSec    int     `yaml:"cooldown_sec"`

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -314,6 +314,7 @@ func strategyParamsToMap(name string, params interface{}) (map[string]interface{
 		return map[string]interface{}{
 			"ema_fast_period":         cp.EMAFastPeriod,
 			"ema_slow_period":         cp.EMASlowPeriod,
+			"trend_ema_period":        cp.TrendEMAPeriod,
 			"take_profit_pct":         cp.TakeProfitPct,
 			"stop_loss_pct":           cp.StopLossPct,
 			"cooldown_sec":            cp.CooldownSec,

--- a/pkg/strategy/scalping/params.go
+++ b/pkg/strategy/scalping/params.go
@@ -4,6 +4,10 @@ package scalping
 type Params struct {
 	EMAFastPeriod        int                       `yaml:"ema_fast_period"`
 	EMASlowPeriod        int                       `yaml:"ema_slow_period"`
+	// TrendEMAPeriod is the period of the long-term trend EMA used as a trend
+	// filter. BUY signals are only emitted when the current price is above this
+	// EMA, indicating an overall uptrend. Set to 0 to disable (default).
+	TrendEMAPeriod       int                       `yaml:"trend_ema_period"`
 	TakeProfitPct        float64                   `yaml:"take_profit_pct"`
 	StopLossPct          float64                   `yaml:"stop_loss_pct"`
 	CooldownSec          int                       `yaml:"cooldown_sec"`

--- a/pkg/strategy/scalping/strategy.go
+++ b/pkg/strategy/scalping/strategy.go
@@ -45,6 +45,11 @@ type Strategy struct {
 	rsiOverbought float64
 	rsiOversold   float64
 
+	// trendEMAPeriod is the long-term EMA period used as a trend direction
+	// filter. When > 0, BUY signals are suppressed if the current price is
+	// below this EMA (= downtrend). 0 disables the filter.
+	trendEMAPeriod int
+
 	symbolParams map[string]SymbolOverride
 
 	marketSpecSvc MarketSpecService
@@ -94,6 +99,7 @@ func New(cfg Params) *Strategy { //nolint:gocritic // hugeParam: Params is passe
 		rsiPeriod:            cfg.RSIPeriod,
 		rsiOverbought:        rsiOverbought,
 		rsiOversold:          rsiOversold,
+		trendEMAPeriod:       cfg.TrendEMAPeriod,
 		symbolParams:         cfg.SymbolParams,
 	}
 }
@@ -177,6 +183,9 @@ func (s *Strategy) Initialize(config map[string]interface{}) error {
 	if v, ok := config["rsi_oversold"].(float64); ok {
 		s.rsiOversold = v
 	}
+	if v, ok := config["trend_ema_period"].(int); ok {
+		s.trendEMAPeriod = v
+	}
 	// Parse per-symbol overrides.  strategyParamsToMap provides
 	// map[string]map[string]interface{}; GetConfig/UpdateConfig roundtrip
 	// provides map[string]SymbolOverride.  Handle both.
@@ -236,6 +245,7 @@ func (s *Strategy) GetConfig() map[string]interface{} {
 		"rsi_period":              s.rsiPeriod,
 		"rsi_overbought":          s.rsiOverbought,
 		"rsi_oversold":            s.rsiOversold,
+		"trend_ema_period":        s.trendEMAPeriod,
 		"symbol_params":           s.symbolParams,
 	}
 }
@@ -284,13 +294,29 @@ func (s *Strategy) GenerateSignal(ctx context.Context, data *strategy.MarketData
 			map[string]interface{}{"reason": "no_new_crossover", "ema_fast": emaFast, "ema_slow": emaSlow}), nil
 	}
 
-	// Snapshot RSI config under read lock (these fields may be updated concurrently
-	// by UpdateConfig called from the HTTP API handler).
+	// Snapshot RSI and trend config under read lock (these fields may be updated
+	// concurrently by UpdateConfig called from the HTTP API handler).
 	s.mu.RLock()
 	rsiPeriod := s.rsiPeriod
 	rsiOverbought := s.rsiOverbought
 	rsiOversold := s.rsiOversold
+	trendEMAPeriod := s.trendEMAPeriod
 	s.mu.RUnlock()
+
+	// Trend filter: suppress BUY when price is below the long-term trend EMA.
+	// This avoids entering longs during a downtrend even if the fast/slow EMA
+	// produces a golden cross (temporary bounce).
+	if action == strategy.SignalBuy && trendEMAPeriod > 0 {
+		if len(history) < trendEMAPeriod {
+			return s.CreateSignal(data.Symbol, strategy.SignalHold, 0, data.Price, 0,
+				map[string]interface{}{"reason": "trend_filter_insufficient_history", "ema_fast": emaFast, "ema_slow": emaSlow}), nil
+		}
+		emaTrend := s.calculateEMA(history, trendEMAPeriod)
+		if data.Price < emaTrend {
+			return s.CreateSignal(data.Symbol, strategy.SignalHold, 0, data.Price, 0,
+				map[string]interface{}{"reason": "trend_filter", "ema_fast": emaFast, "ema_slow": emaSlow, "ema_trend": emaTrend}), nil
+		}
+	}
 
 	// RSI filter
 	if action != strategy.SignalHold && rsiPeriod > 0 {

--- a/pkg/strategy/scalping/strategy_test.go
+++ b/pkg/strategy/scalping/strategy_test.go
@@ -482,3 +482,112 @@ func TestInitialize_SymbolParams(t *testing.T) {
 		t.Errorf("BTC_JPY should use global defaults: want fast=9 slow=21, got fast=%d slow=%d", fast, slow)
 	}
 }
+
+// ── Trend EMA filter ─────────────────────────────────────────────────────────
+
+func TestTrendEMAFilter_BlocksBuyInDowntrend(t *testing.T) {
+	// Build a history that starts high (so EMA(7) is high), then drops sharply.
+	// EMA(3) fast may cross above EMA(5) slow on a small bounce, but price
+	// (103) is still far below the long-term EMA(7) seeded by the earlier
+	// 200-series → BUY must be suppressed.
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TrendEMAPeriod: 7,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    0,
+		MaxDailyTrades: 1000,
+		OrderNotional:  100.0,
+		FeeRate:        0.001,
+	})
+
+	prices := []float64{200, 200, 200, 200, 200, 200, 200, 100, 100, 101, 102, 103}
+	hist := makeHistory(prices...)
+	latest := hist[len(hist)-1]
+
+	sig, err := s.GenerateSignal(context.Background(), &latest, hist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig.Action == strategy.SignalBuy {
+		t.Errorf("expected BUY to be blocked by trend filter, got BUY (ema_trend=%v)", sig.Metadata["ema_trend"])
+	}
+}
+
+func TestTrendEMAFilter_AllowsBuyInUptrend(t *testing.T) {
+	// Steadily rising prices: EMA(7,5,3) all converge upward, price > EMA(7).
+	// A golden cross should produce a BUY that is NOT blocked by the trend filter.
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TrendEMAPeriod: 7,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    0,
+		MaxDailyTrades: 1000,
+		OrderNotional:  100.0,
+		FeeRate:        0.001,
+	})
+
+	prices := []float64{100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110}
+	hist := makeHistory(prices...)
+	latest := hist[len(hist)-1]
+
+	sig, err := s.GenerateSignal(context.Background(), &latest, hist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig.Metadata["reason"] == "trend_filter" {
+		t.Errorf("BUY should be allowed in uptrend, but was blocked by trend_filter (ema_trend=%v)", sig.Metadata["ema_trend"])
+	}
+}
+
+func TestTrendEMAFilter_Disabled_WhenZero(t *testing.T) {
+	// TrendEMAPeriod=0 → filter disabled; trend_filter reason must never appear.
+	s := New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TrendEMAPeriod: 0,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    0,
+		MaxDailyTrades: 1000,
+		OrderNotional:  100.0,
+		FeeRate:        0.001,
+	})
+
+	prices := []float64{200, 200, 200, 200, 200, 200, 200, 100, 100, 101, 102, 103}
+	hist := makeHistory(prices...)
+	latest := hist[len(hist)-1]
+
+	sig, err := s.GenerateSignal(context.Background(), &latest, hist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reason, _ := sig.Metadata["reason"].(string); reason == "trend_filter" {
+		t.Error("trend_filter should be disabled when TrendEMAPeriod=0")
+	}
+}
+
+func TestTrendEMAFilter_Initialize_RoundTrip(t *testing.T) {
+	s := newTestStrategy()
+	err := s.Initialize(map[string]interface{}{
+		"ema_fast_period":  3,
+		"ema_slow_period":  5,
+		"trend_ema_period": 50,
+		"take_profit_pct":  1.0,
+		"stop_loss_pct":    0.5,
+		"cooldown_sec":     0,
+		"max_daily_trades": 1000,
+		"order_notional":   100.0,
+		"fee_rate":         0.001,
+	})
+	if err != nil {
+		t.Fatalf("Initialize error: %v", err)
+	}
+	cfg := s.GetConfig()
+	if got, ok := cfg["trend_ema_period"].(int); !ok || got != 50 {
+		t.Errorf("GetConfig trend_ema_period: want 50, got %v", cfg["trend_ema_period"])
+	}
+}


### PR DESCRIPTION
## Problem

The current EMA crossover strategy is long-only. During a downtrend, a temporary golden cross can still trigger a BUY, which typically gets stopped out at -1.0% as the downtrend resumes. This pattern is a primary driver of losses.

## Changes

Adds a configurable long-term EMA (`trend_ema_period`) as a trend direction filter.

```
BUY signal conditions:
  EMA(fast) > EMA(slow)          ← existing golden cross
  AND price > EMA(trend_period)  ← NEW: confirms overall uptrend
```

When `price < EMA(trend_ema_period)`, a BUY signal is suppressed and returned as HOLD with `reason: trend_filter`.

## Configuration

```yaml
strategy_params:
  scalping:
    trend_ema_period: 50  # 0 = disabled (default, fully backward-compatible)
```

## Backward Compatibility

Setting `trend_ema_period: 0` (or omitting it) disables the filter — existing behavior is preserved exactly.

## Tests

- `TestTrendEMAFilter_BlocksBuyInDowntrend`: BUY is suppressed when price is below the trend EMA
- `TestTrendEMAFilter_AllowsBuyInUptrend`: BUY is allowed when price is above the trend EMA
- `TestTrendEMAFilter_Disabled_WhenZero`: filter is a no-op when period is 0
- `TestTrendEMAFilter_Initialize_RoundTrip`: `Initialize` / `GetConfig` round-trip preserves the value

All 16 packages green ✅