### PR TITLE
refactor(ci): unify duplicated workflow commands with Makefile targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: go mod verify
 
     - name: Run tests (race + shuffle)
-      run: go test -race -shuffle=on ./...
+      run: make test-race
 
     - name: Generate coverage report
       run: go test -coverprofile=coverage.out ./...
@@ -55,9 +55,7 @@ jobs:
       run: go mod download
 
     - name: Verify go.mod is tidy
-      run: |
-        go mod tidy
-        git diff --exit-code -- go.mod go.sum
+      run: make tidy-check
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -25,8 +25,5 @@ jobs:
           go-version: '1.26.x'
           cache: true
 
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
-
       - name: Run govulncheck
-        run: govulncheck ./...
+        run: make vuln


### PR DESCRIPTION
## Motivation
CI workflows duplicated shell commands that already existed as Makefile targets. Consolidating them ensures local (`make ...`) and CI run the exact same recipes, eliminating "passes locally but fails in CI" drift and single-source-of-truth violations.

## Changes

### ci.yml
| Before | After |
|---|---|
| `go test -race -shuffle=on ./...` | `make test-race` |
| `go mod tidy && git diff --exit-code -- go.mod go.sum` | `make tidy-check` |

### govulncheck.yml
| Before | After |
|---|---|
| `go install govulncheck@latest` + `govulncheck ./...` (2 steps) | `make vuln` (1 step) |

## Commands intentionally left inline
The following are not moved to Makefile:

- **coverage**: `go test -coverprofile=coverage.out ./...` — the existing `test-coverage` target generates an HTML report, which differs from what the codecov action expects.
- **build**: `go build ./pkg/... ./internal/...` plus the example build — no equivalent lightweight target exists.
- **security (gosec)**: the SARIF-generation + finding-count logic is complex enough that moving it into the Makefile would hurt readability.

## Verification
Confirmed `make -n test-race` / `make -n tidy-check` / `make -n vuln` expand to the expected recipes. CI step output is unchanged — just an extra `make` wrapper.
