### PR TITLE
test: add unit tests for pkg/strategy and internal/utils (coverage uplift)

### DIFF
--- a/internal/utils/timezone_test.go
+++ b/internal/utils/timezone_test.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadJST_Succeeds(t *testing.T) {
+	loc, err := LoadJST()
+	if err != nil {
+		t.Fatalf("LoadJST error: %v", err)
+	}
+	if loc == nil {
+		t.Fatal("LoadJST returned nil location")
+	}
+	// Asia/Tokyo offset is always +09:00, regardless of season.
+	_, offset := time.Now().In(loc).Zone()
+	if offset != 9*3600 {
+		t.Errorf("expected offset 9h, got %ds", offset)
+	}
+}
+
+func TestNowInJST_HasJSTOffset(t *testing.T) {
+	now := NowInJST()
+	_, offset := now.Zone()
+	if offset != 9*3600 && offset != 0 { // 0 = UTC fallback
+		t.Errorf("expected +9h or UTC fallback, got %ds", offset)
+	}
+}
+
+func TestTodayInJST_FormatYYYYMMDD(t *testing.T) {
+	got := TodayInJST()
+	if _, err := time.Parse("2006-01-02", got); err != nil {
+		t.Errorf("TodayInJST format invalid %q: %v", got, err)
+	}
+}
+
+func TestToJST_ConvertsUTCToJST(t *testing.T) {
+	utc := time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC)
+	jst := ToJST(utc)
+	if !jst.Equal(utc) {
+		t.Error("ToJST must preserve the instant (same moment)")
+	}
+	_, offset := jst.Zone()
+	if offset != 9*3600 && offset != 0 {
+		t.Errorf("ToJST zone offset=%ds, want 9h or UTC fallback", offset)
+	}
+	// Component check: 00:00 UTC == 09:00 JST same date
+	if offset == 9*3600 {
+		if h, m, s := jst.Clock(); h != 9 || m != 0 || s != 0 {
+			t.Errorf("expected 09:00:00 JST, got %02d:%02d:%02d", h, m, s)
+		}
+	}
+}
+
+func TestToJST_IdempotentOnJSTInput(t *testing.T) {
+	loc, err := LoadJST()
+	if err != nil {
+		t.Skip("JST unavailable on this system")
+	}
+	orig := time.Date(2026, 4, 18, 12, 34, 56, 0, loc)
+	got := ToJST(orig)
+	if !got.Equal(orig) {
+		t.Error("ToJST on JST input must return equal instant")
+	}
+}

--- a/pkg/strategy/base_test.go
+++ b/pkg/strategy/base_test.go
@@ -1,0 +1,206 @@
+package strategy
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// ── BaseStrategy metadata ────────────────────────────────────────────────────
+
+func TestBaseStrategy_Metadata(t *testing.T) {
+	bs := NewBaseStrategy("scalping", "desc", "1.0.0")
+	if bs.Name() != "scalping" {
+		t.Errorf("Name()=%q", bs.Name())
+	}
+	if bs.Description() != "desc" {
+		t.Errorf("Description()=%q", bs.Description())
+	}
+	if bs.Version() != "1.0.0" {
+		t.Errorf("Version()=%q", bs.Version())
+	}
+	if bs.IsRunning() {
+		t.Error("IsRunning must be false initially")
+	}
+	if bs.GetConfig() == nil {
+		t.Error("GetConfig returned nil map")
+	}
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────────────
+
+func TestBaseStrategy_StartStop(t *testing.T) {
+	bs := NewBaseStrategy("x", "x", "x")
+	ctx := context.Background()
+
+	if err := bs.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !bs.IsRunning() || !bs.GetStatus().IsRunning {
+		t.Error("after Start, IsRunning must be true")
+	}
+	if bs.GetStatus().StartTime.IsZero() {
+		t.Error("StartTime must be set by Start")
+	}
+
+	if err := bs.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if bs.IsRunning() || bs.GetStatus().IsRunning {
+		t.Error("after Stop, IsRunning must be false")
+	}
+}
+
+func TestBaseStrategy_Reset_ClearsCounters(t *testing.T) {
+	bs := NewBaseStrategy("x", "x", "x")
+	bs.UpdateSignalCount(SignalBuy)
+	bs.UpdateMetrics(100, true)
+
+	if err := bs.Reset(); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if bs.GetStatus().TotalSignals != 0 {
+		t.Errorf("TotalSignals after Reset=%d", bs.GetStatus().TotalSignals)
+	}
+	if bs.GetMetrics().TotalTrades != 0 {
+		t.Errorf("TotalTrades after Reset=%d", bs.GetMetrics().TotalTrades)
+	}
+	if bs.GetStatus().SignalsByAction == nil {
+		t.Error("SignalsByAction must be re-initialized (non-nil) after Reset")
+	}
+}
+
+// ── Default overrides ────────────────────────────────────────────────────────
+
+func TestBaseStrategy_DefaultOverrides(t *testing.T) {
+	bs := NewBaseStrategy("x", "x", "x")
+	if bs.GetStopLossPrice(1000) != 0 {
+		t.Error("GetStopLossPrice default must be 0")
+	}
+	if bs.GetTakeProfitPrice(1000) != 0 {
+		t.Error("GetTakeProfitPrice default must be 0")
+	}
+	if bs.GetBaseNotional("BTC_JPY") != 0 {
+		t.Error("GetBaseNotional default must be 0")
+	}
+	cfg := bs.GetAutoScaleConfig()
+	if cfg.Enabled {
+		t.Error("AutoScale default must be disabled")
+	}
+	if cfg.BalancePct != 80.0 {
+		t.Errorf("AutoScale default BalancePct=%v, want 80", cfg.BalancePct)
+	}
+	// Coverage for no-op default methods
+	bs.RecordTrade()
+	bs.InitializeDailyTradeCount(5)
+}
+
+// ── UpdateSignalCount ────────────────────────────────────────────────────────
+
+func TestBaseStrategy_UpdateSignalCount(t *testing.T) {
+	bs := NewBaseStrategy("x", "x", "x")
+	bs.UpdateSignalCount(SignalBuy)
+	bs.UpdateSignalCount(SignalBuy)
+	bs.UpdateSignalCount(SignalSell)
+
+	st := bs.GetStatus()
+	if st.TotalSignals != 3 {
+		t.Errorf("TotalSignals=%d, want 3", st.TotalSignals)
+	}
+	if st.SignalsByAction[SignalBuy] != 2 {
+		t.Errorf("BUY count=%d, want 2", st.SignalsByAction[SignalBuy])
+	}
+	if st.SignalsByAction[SignalSell] != 1 {
+		t.Errorf("SELL count=%d, want 1", st.SignalsByAction[SignalSell])
+	}
+	if st.LastSignalTime.IsZero() {
+		t.Error("LastSignalTime must be set")
+	}
+}
+
+// ── UpdateMetrics ────────────────────────────────────────────────────────────
+
+func TestBaseStrategy_UpdateMetrics_WinLoss(t *testing.T) {
+	bs := NewBaseStrategy("x", "x", "x")
+	bs.UpdateMetrics(100, true)
+	bs.UpdateMetrics(50, true)
+	bs.UpdateMetrics(-30, false)
+	bs.UpdateMetrics(-70, false)
+
+	m := bs.GetMetrics()
+	if m.TotalTrades != 4 {
+		t.Errorf("TotalTrades=%d", m.TotalTrades)
+	}
+	if m.WinningTrades != 2 || m.LosingTrades != 2 {
+		t.Errorf("wins=%d losses=%d", m.WinningTrades, m.LosingTrades)
+	}
+	if m.WinRate != 50.0 {
+		t.Errorf("WinRate=%v", m.WinRate)
+	}
+	if m.TotalProfit != 50 { // 100+50-30-70
+		t.Errorf("TotalProfit=%v", m.TotalProfit)
+	}
+	if m.AverageProfit != 12.5 {
+		t.Errorf("AverageProfit=%v", m.AverageProfit)
+	}
+	if m.MaxProfit != 100 {
+		t.Errorf("MaxProfit=%v", m.MaxProfit)
+	}
+	if m.MaxLoss != -70 {
+		t.Errorf("MaxLoss=%v", m.MaxLoss)
+	}
+	// ProfitFactor = MaxProfit / -MaxLoss = 100/70 ≈ 1.428
+	if m.ProfitFactor < 1.4 || m.ProfitFactor > 1.45 {
+		t.Errorf("ProfitFactor=%v", m.ProfitFactor)
+	}
+}
+
+// ── ValidateSignal ───────────────────────────────────────────────────────────
+
+func TestBaseStrategy_ValidateSignal_Valid(t *testing.T) {
+	bs := NewBaseStrategy("x", "x", "x")
+	sig := &Signal{Symbol: "BTC_JPY", Action: SignalBuy, Strength: 0.5, Price: 1000, Quantity: 0.01}
+	if err := bs.ValidateSignal(sig); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+func TestBaseStrategy_ValidateSignal_Errors(t *testing.T) {
+	bs := NewBaseStrategy("x", "x", "x")
+	cases := []struct {
+		name string
+		sig  *Signal
+	}{
+		{"nil", nil},
+		{"empty_symbol", &Signal{Action: SignalBuy, Strength: 0.5, Price: 1000}},
+		{"bad_action", &Signal{Symbol: "X", Action: "NOPE", Strength: 0.5, Price: 1000}},
+		{"strength_low", &Signal{Symbol: "X", Action: SignalBuy, Strength: -0.1, Price: 1000}},
+		{"strength_high", &Signal{Symbol: "X", Action: SignalBuy, Strength: 1.1, Price: 1000}},
+		{"zero_price", &Signal{Symbol: "X", Action: SignalBuy, Strength: 0.5, Price: 0}},
+		{"negative_qty", &Signal{Symbol: "X", Action: SignalBuy, Strength: 0.5, Price: 1, Quantity: -1}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := bs.ValidateSignal(c.sig); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+// ── CreateSignal ─────────────────────────────────────────────────────────────
+
+func TestBaseStrategy_CreateSignal(t *testing.T) {
+	bs := NewBaseStrategy("x", "x", "x")
+	before := time.Now().Add(-time.Second)
+	sig := bs.CreateSignal("BTC_JPY", SignalBuy, 0.8, 1234, 0.01, map[string]interface{}{"k": "v"})
+	if sig.Symbol != "BTC_JPY" || sig.Action != SignalBuy {
+		t.Errorf("symbol/action mismatch: %+v", sig)
+	}
+	if sig.Timestamp.Before(before) {
+		t.Error("Timestamp must be ≥ now-1s")
+	}
+	if sig.Metadata["k"] != "v" {
+		t.Errorf("Metadata not set")
+	}
+}

--- a/pkg/strategy/registry_test.go
+++ b/pkg/strategy/registry_test.go
@@ -1,0 +1,107 @@
+package strategy
+
+import (
+	"sort"
+	"sync"
+	"testing"
+)
+
+// ── Registry ──────────────────────────────────────────────────────────────────
+
+func TestNewRegistry_IsEmpty(t *testing.T) {
+	r := NewRegistry()
+	if names := r.Names(); len(names) != 0 {
+		t.Errorf("expected empty registry, got %v", names)
+	}
+}
+
+func TestRegistry_RegisterAndCreate(t *testing.T) {
+	r := NewRegistry()
+	r.Register("foo", func() Strategy { return NewDummyStrategy("foo") })
+	got, err := r.Create("foo")
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if got.Name() != "foo" {
+		t.Errorf("expected Name()=foo, got %q", got.Name())
+	}
+}
+
+func TestRegistry_CreateUnknownReturnsError(t *testing.T) {
+	r := NewRegistry()
+	if _, err := r.Create("missing"); err == nil {
+		t.Error("expected error for unknown strategy")
+	}
+}
+
+func TestRegistry_RegisterDuplicatePanics(t *testing.T) {
+	r := NewRegistry()
+	r.Register("dup", func() Strategy { return NewDummyStrategy("dup") })
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on duplicate Register")
+		}
+	}()
+	r.Register("dup", func() Strategy { return NewDummyStrategy("dup") })
+}
+
+func TestRegistry_NamesReturnsAll(t *testing.T) {
+	r := NewRegistry()
+	r.Register("a", func() Strategy { return NewDummyStrategy("a") })
+	r.Register("b", func() Strategy { return NewDummyStrategy("b") })
+	names := r.Names()
+	sort.Strings(names)
+	if len(names) != 2 || names[0] != "a" || names[1] != "b" {
+		t.Errorf("expected [a b], got %v", names)
+	}
+}
+
+func TestRegistry_ConcurrentAccess(t *testing.T) {
+	r := NewRegistry()
+	r.Register("x", func() Strategy { return NewDummyStrategy("x") })
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); _, _ = r.Create("x") }()
+		go func() { defer wg.Done(); _ = r.Names() }()
+	}
+	wg.Wait()
+}
+
+// ── Global registry ──────────────────────────────────────────────────────────
+
+func TestGlobalRegister_AndList(t *testing.T) {
+	// Use a unique name to avoid colliding with other tests.
+	const name = "__test_global_strategy__"
+	Register(name, func() Strategy { return NewDummyStrategy(name) })
+
+	found := false
+	for _, n := range List() {
+		if n == name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected %q in global List(), got %v", name, List())
+	}
+
+	s, err := Create(name)
+	if err != nil {
+		t.Fatalf("Create(%q) error: %v", name, err)
+	}
+	if s.Name() != name {
+		t.Errorf("Create returned strategy with Name()=%q", s.Name())
+	}
+}
+
+func TestGlobal_Returns_SameRegistry(t *testing.T) {
+	if Global() == nil {
+		t.Error("Global() returned nil")
+	}
+	a := Global()
+	b := Global()
+	if a != b {
+		t.Error("Global() must return the same instance on repeated calls")
+	}
+}

--- a/pkg/strategy/testing_test.go
+++ b/pkg/strategy/testing_test.go
@@ -1,0 +1,43 @@
+package strategy
+
+import "context"
+
+// DummyStrategy is a minimal Strategy implementation used by unit tests in
+// this package. It embeds *BaseStrategy to inherit lifecycle/metrics plumbing
+// and returns a HOLD signal with the configured price.
+type DummyStrategy struct {
+	*BaseStrategy
+}
+
+// NewDummyStrategy creates a DummyStrategy with the given name.
+func NewDummyStrategy(name string) *DummyStrategy {
+	return &DummyStrategy{BaseStrategy: NewBaseStrategy(name, "test strategy", "0.0.0")}
+}
+
+// GenerateSignal returns a HOLD signal echoing the input price.
+func (d *DummyStrategy) GenerateSignal(_ context.Context, data *MarketData, _ []MarketData) (*Signal, error) {
+	if data == nil {
+		return d.CreateSignal("", SignalHold, 0, 0, 0, nil), nil
+	}
+	return d.CreateSignal(data.Symbol, SignalHold, 0, data.Price, 0, nil), nil
+}
+
+// Analyze mirrors GenerateSignal over a batch.
+func (d *DummyStrategy) Analyze(data []MarketData) (*Signal, error) {
+	if len(data) == 0 {
+		return d.CreateSignal("", SignalHold, 0, 0, 0, nil), nil
+	}
+	latest := data[len(data)-1]
+	return d.GenerateSignal(context.Background(), &latest, data)
+}
+
+// Initialize stores the config map on the embedded BaseStrategy.
+func (d *DummyStrategy) Initialize(config map[string]interface{}) error {
+	d.BaseStrategy.config = config
+	return nil
+}
+
+// UpdateConfig is an alias for Initialize.
+func (d *DummyStrategy) UpdateConfig(config map[string]interface{}) error {
+	return d.Initialize(config)
+}


### PR DESCRIPTION
## Motivation
First step of the coverage-improvement plan agreed in an earlier session: start by covering public packages that were at 0%.

## Before / After
| Package | Before | After |
|---|---|---|
| `pkg/strategy` | **0.0%** | **100.0%** |
| `internal/utils` | **0.0%** | **76.9%** |

## Added tests

### `pkg/strategy`
- **registry_test.go**: Register / Create / Names / duplicate-registration panic / concurrent access / global registry / `Global()` singleton behavior.
- **base_test.go**: metadata getters, lifecycle (Start/Stop/IsRunning), counter reset, default overrides (StopLoss=0, TP=0, BaseNotional=0, AutoScale disabled), UpdateSignalCount, UpdateMetrics (Win/Loss/WinRate/MaxProfit/MaxLoss/ProfitFactor), ValidateSignal (7 error cases + 1 valid case), CreateSignal.
- **testing_test.go**: shared `DummyStrategy` test helper that embeds `BaseStrategy`.

### `internal/utils`
- **timezone_test.go**: `LoadJST` offset check, `NowInJST`/`TodayInJST` format checks, `ToJST` UTC→JST conversion and JST→JST idempotency.

## Why `internal/utils` is not 100%
The remaining 23.1% is the **UTC fallback branch** triggered when tzdata is missing. Reaching it requires physically deleting `/usr/share/zoneinfo/Asia/Tokyo`, which is not feasible in a portable unit test, so it is intentionally left uncovered.

## Next targets (follow-up PRs)
Still at low coverage:
- `pkg/engine` 0% (~420 lines; needs a review of mock-injection seams first)
- `internal/domain` 0% (mostly pure struct definitions)
- `internal/infra/exchange/bitflyer` 7.4% (needs HTTP mocks)
- `internal/usecase/trading/order` 25.0%
- `internal/usecase/trading/balance` 23.3%

## Verification
- `go test -race -shuffle=on ./...` — all pass
- `golangci-lint run ./...` — 0 issues
