### PR TITLE
ci(dependabot): add example/ ecosystem and use Conventional Commits prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,16 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "deps"
+      prefix: "build(deps)"
+  - package-ecosystem: "gomod"
+    directory: "/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build(deps)"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "ci"
+      prefix: "ci(deps)"


### PR DESCRIPTION
## Motivation

Two recurring issues that were hand-fixed on PR #90 and would recur on every dependabot PR:

1. **`example/go.sum` was stale after bumps.** The repo has a nested module at `example/` (`example/go.mod`), but `.github/dependabot.yml` only watched the root module. When dependabot bumped `oapi-codegen/runtime` in the root, `example/go.sum` was left at the old version, breaking the **Docker Build Test** stage (`missing go.sum entry`).
2. **PR titles failed Conventional Commits validation.** The previous `commit-message.prefix` of `deps` / `ci` is not in the allowed type list (`feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`), so every dependabot PR failed the `Validate PR title (Conventional Commits)` check until manually retitled.

## Changes (`.github/dependabot.yml`)

- Add a second `gomod` entry for `/example` so the nested module is bumped in lockstep with the root.
- Rename `commit-message.prefix`:
  - `deps` → `build(deps)` (gomod, both root and `/example`)
  - `ci` → `ci(deps)` (github-actions)

## Verification

- YAML structure is unchanged besides additive entries; no schema risk.
- After merge, the next dependabot run should open PRs whose titles already pass the semantic-pr check, and Docker Build Test should pass without manual `cd example && go mod tidy`.

## Related

- PR #90 (`oapi-codegen/runtime` bump) — manually fixed both symptoms; this PR prevents recurrence.
