### PR TITLE
fix(pnl): correct dashboard PnL aggregation and retention semantics

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -87,6 +87,15 @@ paths:
       summary: 取引履歴の取得
       parameters:
         - $ref: "#/components/parameters/LimitParam"
+        - name: since
+          in: query
+          description: |
+            取得範囲を時刻で絞り込む。
+            - `today`: JST 当日 0:00 以降の全トレード（limit は無視）
+            - RFC3339 タイムスタンプ (例: `2026-04-19T00:00:00+09:00`): その時刻以降のトレード
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: 取引履歴（新しい順）

--- a/internal/adapter/http/api.gen.go
+++ b/internal/adapter/http/api.gen.go
@@ -476,6 +476,11 @@ type GetApiStatusParams struct {
 type GetApiTradesParams struct {
 	// Limit 取得件数（デフォルト: 50）
 	Limit *LimitParam `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Since 取得範囲を時刻で絞り込む。
+	// - `today`: JST 当日 0:00 以降の全トレード（limit は無視）
+	// - RFC3339 タイムスタンプ (例: `2026-04-19T00:00:00+09:00`): その時刻以降のトレード
+	Since *string `form:"since,omitempty" json:"since,omitempty"`
 }
 
 // PostApiConfigJSONRequestBody defines body for PostApiConfig for application/json ContentType.
@@ -713,6 +718,14 @@ func (siw *ServerInterfaceWrapper) GetApiTrades(w http.ResponseWriter, r *http.R
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "since" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "since", r.URL.Query(), &params.Since, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "since", Err: err})
 		return
 	}
 

--- a/internal/adapter/http/contracts.go
+++ b/internal/adapter/http/contracts.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	"github.com/bmf-san/gogocoin/internal/domain"
 	strategy "github.com/bmf-san/gogocoin/pkg/strategy"
@@ -17,6 +18,7 @@ type DatabaseService interface {
 
 	// Trade operations
 	GetRecentTrades(limit int) ([]domain.Trade, error)
+	GetTradesSince(since time.Time, limit int) ([]domain.Trade, error)
 	GetTradesCount() (int, error)
 	GetTodayTradesCount() (int, error)
 

--- a/internal/adapter/http/handler_data.go
+++ b/internal/adapter/http/handler_data.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -109,6 +110,31 @@ func (s *Server) GetApiTrades(ctx context.Context, request GetApiTradesRequestOb
 		limit = *request.Params.Limit
 	}
 
+	// Optional since filter. Supports "today" (JST calendar day) or RFC3339.
+	if request.Params.Since != nil && *request.Params.Since != "" {
+		since, err := parseSince(*request.Params.Since)
+		if err != nil {
+			s.logger.System().WithError(err).WithField("since", *request.Params.Since).
+				Warn("Invalid since parameter for /api/trades")
+			msg := "Invalid 'since' parameter: " + err.Error()
+			return GetApiTrades500JSONResponse{InternalServerErrorJSONResponse{Message: &msg}}, nil
+		}
+		// "today" returns all rows for the day; other since values respect limit.
+		effectiveLimit := limit
+		if *request.Params.Since == "today" {
+			effectiveLimit = 0
+		}
+		trades, err := s.db.GetTradesSince(since, effectiveLimit)
+		if err != nil {
+			s.logger.Error("Failed to get trades since: " + err.Error())
+			msg := "Internal server error"
+			return GetApiTrades500JSONResponse{InternalServerErrorJSONResponse{Message: &msg}}, nil
+		}
+		s.logger.System().WithField("count", len(trades)).WithField("since", since).
+			Info("Returning trades from API (since)")
+		return GetApiTrades200JSONResponse(domainTradesToAPI(trades)), nil
+	}
+
 	trades, err := s.db.GetRecentTrades(limit)
 	if err != nil {
 		s.logger.Error("Failed to get trades: " + err.Error())
@@ -118,6 +144,27 @@ func (s *Server) GetApiTrades(ctx context.Context, request GetApiTradesRequestOb
 
 	s.logger.System().WithField("count", len(trades)).Info("Returning trades from API")
 	return GetApiTrades200JSONResponse(domainTradesToAPI(trades)), nil
+}
+
+// parseSince resolves the `since` query parameter into an absolute time.
+// Accepted values:
+//   - "today": JST calendar day start (00:00:00 JST)
+//   - any value parseable as RFC3339
+func parseSince(raw string) (time.Time, error) {
+	if raw == "today" {
+		jst, err := time.LoadLocation("Asia/Tokyo")
+		if err != nil {
+			// Fallback: fixed +09:00 offset
+			jst = time.FixedZone("JST", 9*60*60)
+		}
+		now := time.Now().In(jst)
+		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, jst), nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t, nil
 }
 
 // GetApiPerformance implements StrictServerInterface - get performance metrics

--- a/internal/adapter/http/handler_data_test.go
+++ b/internal/adapter/http/handler_data_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseSince_Today(t *testing.T) {
+	got, err := parseSince("today")
+	if err != nil {
+		t.Fatalf("parseSince(today) unexpected error: %v", err)
+	}
+	jst, _ := time.LoadLocation("Asia/Tokyo")
+	now := time.Now().In(jst)
+	want := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, jst)
+	if !got.Equal(want) {
+		t.Errorf("parseSince(today) = %v, want JST start-of-day %v", got, want)
+	}
+}
+
+func TestParseSince_RFC3339(t *testing.T) {
+	in := "2026-04-19T09:15:00+09:00"
+	got, err := parseSince(in)
+	if err != nil {
+		t.Fatalf("parseSince(%q) unexpected error: %v", in, err)
+	}
+	want, _ := time.Parse(time.RFC3339, in)
+	if !got.Equal(want) {
+		t.Errorf("parseSince(%q) = %v, want %v", in, got, want)
+	}
+}
+
+func TestParseSince_Invalid(t *testing.T) {
+	if _, err := parseSince("not-a-date"); err == nil {
+		t.Error("parseSince(not-a-date) expected error, got nil")
+	}
+}

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -1,10 +1,15 @@
 package domain
 
+import "time"
+
 // TradeRepository is the interface for trade data persistence
 type TradeRepository interface {
 	SaveTrade(trade *Trade) error
 	GetRecentTrades(limit int) ([]Trade, error)
 	GetAllTrades() ([]Trade, error)
+	// GetTradesSince returns trades whose executed_at >= since, ordered by
+	// executed_at DESC. Limit is applied only when > 0.
+	GetTradesSince(since time.Time, limit int) ([]Trade, error)
 }
 
 // PositionRepository is the interface for position data persistence

--- a/internal/infra/persistence/repository.go
+++ b/internal/infra/persistence/repository.go
@@ -1,6 +1,8 @@
 package persistence
 
 import (
+	"time"
+
 	"github.com/bmf-san/gogocoin/internal/domain"
 )
 
@@ -42,6 +44,9 @@ func (r *Repository) GetRecentTrades(limit int) ([]domain.Trade, error) {
 }
 func (r *Repository) GetAllTrades() ([]domain.Trade, error) {
 	return r.trade.GetAllTrades()
+}
+func (r *Repository) GetTradesSince(since time.Time, limit int) ([]domain.Trade, error) {
+	return r.trade.GetTradesSince(since, limit)
 }
 func (r *Repository) GetTradesCount() (int, error) {
 	return r.trade.GetTradesCount()

--- a/internal/infra/persistence/trade_repo.go
+++ b/internal/infra/persistence/trade_repo.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/bmf-san/gogocoin/internal/domain"
@@ -71,6 +72,40 @@ func (r *TradeRepository) GetAllTrades() ([]domain.Trade, error) {
 			  executed_at, created_at, updated_at, strategy_name, pnl
 			  FROM trades ORDER BY executed_at ASC`
 	rows, err := r.db.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+	var trades []domain.Trade
+	for rows.Next() {
+		var t domain.Trade
+		if err := rows.Scan(&t.ID, &t.Symbol, &t.Side, &t.Type, &t.Size, &t.Price, &t.Fee,
+			&t.Status, &t.OrderID, &t.ExecutedAt, &t.CreatedAt,
+			&t.UpdatedAt, &t.StrategyName, &t.PnL); err != nil {
+			return nil, err
+		}
+		trades = append(trades, t)
+	}
+	return trades, rows.Err()
+}
+
+// GetTradesSince returns trades whose executed_at >= since, ordered by
+// executed_at DESC. When limit > 0 it caps the number of rows; otherwise
+// all matching rows are returned.
+func (r *TradeRepository) GetTradesSince(since time.Time, limit int) ([]domain.Trade, error) {
+	base := `SELECT id, symbol, side, type, size, price, fee, status, order_id,
+			 executed_at, created_at, updated_at, strategy_name, pnl
+			 FROM trades WHERE executed_at >= ?
+			 ORDER BY executed_at DESC`
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if limit > 0 {
+		rows, err = r.db.db.Query(base+" LIMIT ?", since, limit)
+	} else {
+		rows, err = r.db.db.Query(base, since)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/analytics/performance.go
+++ b/internal/usecase/analytics/performance.go
@@ -114,19 +114,15 @@ func (pa *PerformanceAnalytics) CalculateFromTrades(trades []domain.Trade) domai
 	for i := range trades {
 		trade := &trades[i]
 
-		// Use PnL saved to database
+		// Use PnL saved to database.
+		// Note: calculator.go already persists BUY.PnL = -fee and
+		// SELL.PnL = sellRevenue - totalCost - totalFees, so fees are
+		// already baked in. We only substitute for legacy BUY rows where
+		// PnL was not stored (pnl==0 && fee>0). Substituting for SELL
+		// would double-count fees on any break-even SELL.
 		pnl := trade.PnL
-
-		// Improved handling for PnL = 0 case
-		if pnl == 0 {
-			switch trade.Side {
-			case "BUY":
-				// For BUY trades, record only fee as loss
-				pnl = -trade.Fee
-			case "SELL":
-				// For SELL trades with PnL=0, record only fee as loss
-				pnl = -trade.Fee
-			}
+		if pnl == 0 && trade.Side == "BUY" && trade.Fee > 0 {
+			pnl = -trade.Fee
 		}
 
 		totalPnL += pnl
@@ -229,7 +225,9 @@ func (pa *PerformanceAnalytics) calculateMaxDrawdown(trades []domain.Trade) floa
 
 	for i := range trades {
 		pnl := trades[i].PnL
-		if pnl == 0 && trades[i].Fee > 0 {
+		// Same logic as CalculateFromTrades: only substitute for legacy BUY
+		// rows where PnL was never stored. SELL.PnL already includes fees.
+		if pnl == 0 && trades[i].Side == "BUY" && trades[i].Fee > 0 {
 			pnl = -trades[i].Fee
 		}
 		runningPnL += pnl

--- a/internal/usecase/analytics/performance_test.go
+++ b/internal/usecase/analytics/performance_test.go
@@ -179,6 +179,25 @@ func TestCalculateFromTrades_ZeroPnLHandling(t *testing.T) {
 	}
 }
 
+// TestCalculateFromTrades_SellZeroPnLNoDoubleFee asserts that a SELL row whose
+// stored PnL is exactly 0 (a rare break-even sale where sellRevenue-totalCost
+// equals totalFees) is NOT re-subtracted for fees by CalculateFromTrades.
+// calculator.go already subtracts fees when computing PnL, so substituting
+// pnl = -fee here would double-count the fee.
+func TestCalculateFromTrades_SellZeroPnLNoDoubleFee(t *testing.T) {
+	pa := NewPerformanceAnalytics(nil, nil, nil, 100000)
+
+	trades := []domain.Trade{
+		{Side: "SELL", PnL: 0, Fee: 15},
+	}
+
+	metrics := pa.CalculateFromTrades(trades)
+
+	if math.Abs(metrics.TotalPnL) > 0.01 {
+		t.Errorf("Expected SELL PnL=0 to stay 0 (no double fee), got %.2f", metrics.TotalPnL)
+	}
+}
+
 func TestCalculateSharpeRatio(t *testing.T) {
 	pa := NewPerformanceAnalytics(nil, nil, nil, 100000)
 
@@ -255,9 +274,12 @@ func TestCalculateMaxDrawdown(t *testing.T) {
 			expected: 0.6, // (1000-400)/100000*100 = 0.6%
 		},
 		{
-			name: "Zero PnL with fee",
+			name: "Zero PnL with fee (legacy BUY row)",
 			trades: []domain.Trade{
-				{PnL: 0, Fee: 15}, // Should count as -15
+				// Legacy rows where PnL was never stored have Side="BUY" & PnL=0.
+				// SELL rows with PnL=0 must NOT be substituted to avoid
+				// double-counting fees (calculator.go already subtracts them).
+				{Side: "BUY", PnL: 0, Fee: 15}, // Should count as -15
 			},
 			expected: 0.015, // 15/100000*100 = 0.015%
 		},

--- a/internal/usecase/trading/pnl/calculator_test.go
+++ b/internal/usecase/trading/pnl/calculator_test.go
@@ -50,6 +50,10 @@ func (m *mockTradingRepo) GetAllTrades() ([]domain.Trade, error) {
 	return nil, nil
 }
 
+func (m *mockTradingRepo) GetTradesSince(_ time.Time, _ int) ([]domain.Trade, error) {
+	return nil, nil
+}
+
 func (m *mockTradingRepo) SavePosition(p *domain.Position) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/web/index.html
+++ b/web/index.html
@@ -92,7 +92,7 @@
                     </svg>
                   </div>
                   <p id="total-pnl" class="text-2xl font-bold mb-1">¥0</p>
-                  <span class="text-xs text-secondary">累計</span>
+                  <span id="total-pnl-caption" class="text-xs text-secondary">累計</span>
                 </div>
               </div>
               <!-- Today's P&L -->

--- a/web/script.js
+++ b/web/script.js
@@ -111,6 +111,19 @@ class GogocoinUI {
     // Load initial data
     async loadInitialData() {
         try {
+            // Best-effort: fetch retention setting so the "総損益" caption can
+            // honestly reflect that it represents only the retained window.
+            this.fetchAPI('/api/config').then(cfg => {
+                const days = cfg && cfg.data_retention && cfg.data_retention.retention_days;
+                if (days && Number.isFinite(days)) {
+                    this.retentionDays = days;
+                    const cap = document.getElementById('total-pnl-caption');
+                    if (cap) cap.textContent = days === 1 ? '本日累計' : `直近${days}日累計`;
+                }
+            }).catch(() => {
+                /* optional feature — keep default caption on failure */
+            });
+
             await this.loadDashboardData();
             // Dashboard also shows logs, so load on init
             this.loadLogs().catch(err => {
@@ -126,15 +139,20 @@ class GogocoinUI {
     // Load dashboard data
     async loadDashboardData() {
         try {
-            // Call each API individually to capture detailed errors
+            // Call each API individually to capture detailed errors.
+            // Trades are fetched twice:
+            //   - limit=200: recent rows for the trade list & table
+            //   - since=today: all of today's rows for accurate "本日の損益"
+            //     (the limit=200 slice can truncate heavy scalping days).
             const results = await Promise.allSettled([
                 this.fetchAPI(`/api/status?symbol=${this.selectedSymbol}`),
                 this.fetchAPI('/api/balance'),
                 this.fetchAPI('/api/performance'),
-                this.fetchAPI('/api/trades?limit=200')
+                this.fetchAPI('/api/trades?limit=200'),
+                this.fetchAPI('/api/trades?since=today')
             ]);
 
-            const [statusResult, balanceResult, performanceResult, tradesResult] = results;
+            const [statusResult, balanceResult, performanceResult, tradesResult, todayTradesResult] = results;
 
             // Update only successful data (always update what we can)
             if (statusResult.status === 'fulfilled') {
@@ -151,14 +169,15 @@ class GogocoinUI {
             }
 
             const trades = tradesResult.status === 'fulfilled' ? tradesResult.value : [];
+            const todayTrades = todayTradesResult.status === 'fulfilled' ? todayTradesResult.value : trades;
 
             if (performanceResult.status === 'fulfilled') {
-                this.updatePerformance(performanceResult.value, false, trades);
-                this.updatePerformanceTable(performanceResult.value, false);
+                this.updatePerformance(performanceResult.value, false, todayTrades);
+                this.updatePerformanceTable(performanceResult.value, false, todayTrades);
             } else {
                 console.error('Failed to load performance:', performanceResult.reason);
-                this.updatePerformance(null, true, trades);
-                this.updatePerformanceTable(null, true);
+                this.updatePerformance(null, true, todayTrades);
+                this.updatePerformanceTable(null, true, todayTrades);
             }
 
             if (tradesResult.status === 'fulfilled') {
@@ -482,7 +501,9 @@ class GogocoinUI {
     }
 
     // Update PnL history table
-    updatePerformanceTable(performance, hasError) {
+    // todayTrades: optional array of today's trades, used to reconstruct the
+    // current-day row when there is no previous-day snapshot to diff against.
+    updatePerformanceTable(performance, hasError, todayTrades = []) {
         const tbody = document.querySelector('#pnl-history-table');
 
         if (!tbody) {
@@ -515,18 +536,56 @@ class GogocoinUI {
             .sort((a, b) => (a < b ? 1 : -1))
             .map(d => ({ ...byDate[d], _jstDate: d }));
 
+        const todayStr = new Date(Date.now() + jstOffsetMs).toISOString().split('T')[0];
+
+        // Reconstruct today's totals from actual trade rows when possible.
+        // This is used as the fallback daily delta for the oldest-displayed row
+        // (which has no prev snapshot) when that row happens to be today.
+        let todayPnLFromTrades = null;
+        let todayTradesCount = 0;
+        let todayWinningCount = 0;
+        (todayTrades || []).forEach(t => {
+            if (!t.executed_at) return;
+            const d = new Date(new Date(t.executed_at).getTime() + jstOffsetMs)
+                .toISOString().split('T')[0];
+            if (d !== todayStr) return;
+            if (t.pnl !== undefined && t.pnl !== null) {
+                todayPnLFromTrades = (todayPnLFromTrades || 0) + t.pnl;
+                if (t.pnl > 0.01) todayWinningCount++;
+            }
+            todayTradesCount++;
+        });
+
         // Display up to 10 days, using sorted for delta calculation beyond the cutoff
         const recentData = sorted.slice(0, 10);
 
         tbody.innerHTML = recentData.map((p, i) => {
             const prev = sorted[i + 1]; // older entry for delta
-            const dailyPnL = prev ? p.total_pnl - prev.total_pnl : p.total_pnl;
-            const dailyTrades = prev
-                ? (p.total_trades || 0) - (prev.total_trades || 0)
-                : (p.total_trades || 0);
-            const dailyWinning = prev
-                ? (p.winning_trades || 0) - (prev.winning_trades || 0)
-                : (p.winning_trades || 0);
+            let dailyPnL;
+            let dailyTrades;
+            let dailyWinning;
+            if (prev) {
+                dailyPnL = p.total_pnl - prev.total_pnl;
+                dailyTrades = (p.total_trades || 0) - (prev.total_trades || 0);
+                dailyWinning = (p.winning_trades || 0) - (prev.winning_trades || 0);
+            } else if (p._jstDate === todayStr && todayPnLFromTrades !== null) {
+                // Oldest displayed row is today: compute from trade log directly
+                // instead of using cumulative total as "daily" (would overstate).
+                dailyPnL = todayPnLFromTrades;
+                dailyTrades = todayTradesCount;
+                dailyWinning = todayWinningCount;
+            } else {
+                // No prev snapshot AND no trade-log fallback: show a dash
+                // rather than the misleading cumulative value.
+                return `
+            <tr>
+                <td class="text-sm">${this.escapeHtml(p._jstDate)}</td>
+                <td class="text-right text-secondary">—</td>
+                <td class="text-right text-secondary">—</td>
+                <td class="text-right text-secondary">—</td>
+            </tr>
+        `;
+            }
             const dailyWinRate = dailyTrades > 0 ? (dailyWinning / dailyTrades) * 100 : 0;
             return `
             <tr>


### PR DESCRIPTION
## Summary

Four related fixes around P&L calculation, trade-log completeness, and retention-window display on the dashboard.

## Why

Surfaced while auditing the "総損益 / 本日の損益 / 日次履歴" flow:

| # | Symptom | Root cause |
|---|---|---|
| 1 | A break-even SELL (sellRevenue-totalCost == totalFees) would appear as -fee on the dashboard | analytics/performance.go re-substituted `pnl=-fee` even though calculator.go already subtracted fees |
| 2 | "本日の損益" could go wrong on heavy days | UI computed today's PnL from `/api/trades?limit=200`; once daily volume exceeds 200 rows the earliest trades of the day fall off |
| 3 | Oldest row of the 日次履歴 table showed a huge number | `dailyPnL = p.total_pnl - prev.total_pnl` falls back to `p.total_pnl` when `prev` is undefined; with `retention_days: 7` the tail row has no prev every day |
| 4 | "総損益 / 累計" label implied all-time totals but `CleanupOldData` trims old trades, so it's really "直近 N 日累計" | Label was hard-coded |

## Changes

- **analytics/performance.go**: `pnl==0` substitution now restricted to `Side=="BUY"` (legacy rows); SELL rows keep the stored value. Same in `calculateMaxDrawdown`.
- **/api/trades**: new `since` query parameter. `since=today` returns every trade executed today (JST) bypassing limit; RFC3339 values also accepted. openapi.yaml updated, `oapi-codegen` regenerated, `TradeRepository.GetTradesSince` added with passthrough through `Repository` and test mocks.
- **web/script.js**: dashboard fetches `/api/trades?since=today` in parallel and uses it for 本日損益; `updatePerformanceTable` reconstructs today's row from trade log when it's the tail (no prev snapshot), otherwise shows `—` instead of the cumulative value.
- **web/index.html + script.js**: total-pnl caption populated from `/api/config` (`直近{retention_days}日累計` / `本日累計` when days==1).

## Tests

- `TestCalculateFromTrades_SellZeroPnLNoDoubleFee` (new): SELL/PnL=0 stays 0
- `TestCalculateMaxDrawdown` legacy BUY case now requires `Side="BUY"`
- `TestParseSince_Today / _RFC3339 / _Invalid` (new)
- `go test ./...` / `make lint`: green

## Notes

- Backward-compatible: `since` is optional; clients not passing it see the same behaviour as before.
- No DB migration required.
- "総損益" semantics remain "直近 retention_days 日累計" (保守的案A). If we want truly all-time totals we should stop purging `trades` and only trim logs/market_data — future PR.