### PR TITLE
fix(example/scalping): evaluate cooldown/daily-limit against MarketData.Timestamp

### DIFF
--- a/example/strategy/scalping/strategy.go
+++ b/example/strategy/scalping/strategy.go
@@ -31,6 +31,12 @@ type Strategy struct {
 	lastTradeTime   time.Time
 	dailyTradeCount int
 	lastTradeDate   string
+	// lastSeenTimestamp is the timestamp of the most recently observed MarketData.
+	// Cooldown / daily-limit decisions are evaluated against this value so that
+	// backtest replay (which processes long periods of ticks in seconds of wall
+	// clock) advances the simulated clock correctly. Falls back to time.Now()
+	// when zero (e.g. unit tests that don't set Timestamp).
+	lastSeenTimestamp time.Time
 }
 
 // New creates a Strategy from Params.
@@ -146,6 +152,14 @@ func (s *Strategy) GenerateSignal(_ context.Context, data *strategy.MarketData, 
 		return nil, fmt.Errorf("market data is nil")
 	}
 
+	// Remember the observed tick timestamp so cooldown/daily-limit can be
+	// evaluated in simulated time during backtest replay.
+	if !data.Timestamp.IsZero() {
+		s.mu.Lock()
+		s.lastSeenTimestamp = data.Timestamp
+		s.mu.Unlock()
+	}
+
 	s.mu.RLock()
 	fastPeriod := s.emaFastPeriod
 	slowPeriod := s.emaSlowPeriod
@@ -226,11 +240,20 @@ func (s *Strategy) Analyze(data []strategy.MarketData) (*strategy.Signal, error)
 }
 
 // RecordTrade updates cooldown and daily trade counter.
+//
+// Uses the most recently observed MarketData.Timestamp as "now" so that the
+// strategy works correctly under backtest replay (where wall-clock barely
+// advances). Live operation is unaffected because tick timestamps track
+// wall-clock in real time.
 func (s *Strategy) RecordTrade() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.lastTradeTime = time.Now()
-	today := jstToday()
+	now := s.lastSeenTimestamp
+	if now.IsZero() {
+		now = time.Now()
+	}
+	s.lastTradeTime = now
+	today := jstDate(now)
 	if s.lastTradeDate != today {
 		s.dailyTradeCount = 1
 		s.lastTradeDate = today
@@ -323,13 +346,21 @@ func (s *Strategy) isInCooldown(cooldownSec int) bool {
 	if s.lastTradeTime.IsZero() || cooldownSec == 0 {
 		return false
 	}
-	return time.Since(s.lastTradeTime).Seconds() < float64(cooldownSec)
+	now := s.lastSeenTimestamp
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return now.Sub(s.lastTradeTime).Seconds() < float64(cooldownSec)
 }
 
 func (s *Strategy) isDailyLimitReached(maxDailyTrades int) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.lastTradeDate != jstToday() {
+	now := s.lastSeenTimestamp
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if s.lastTradeDate != jstDate(now) {
 		return false
 	}
 	return s.dailyTradeCount >= maxDailyTrades
@@ -338,7 +369,12 @@ func (s *Strategy) isDailyLimitReached(maxDailyTrades int) bool {
 // jstToday returns today's date string in JST (UTC+9).
 // Counters reset at midnight JST, not UTC, to align with the Japanese trading day.
 func jstToday() string {
-	return time.Now().UTC().Add(9 * time.Hour).Format("2006-01-02")
+	return jstDate(time.Now())
+}
+
+// jstDate returns the JST date string for the given instant.
+func jstDate(t time.Time) string {
+	return t.UTC().Add(9 * time.Hour).Format("2006-01-02")
 }
 
 // calcEMA computes the Exponential Moving Average for the given period.

--- a/example/strategy/scalping/strategy_test.go
+++ b/example/strategy/scalping/strategy_test.go
@@ -1,0 +1,66 @@
+package scalping
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	strategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+func newTestStrategy() *Strategy {
+	return New(Params{
+		EMAFastPeriod:  3,
+		EMASlowPeriod:  5,
+		TakeProfitPct:  1.0,
+		StopLossPct:    0.5,
+		CooldownSec:    300,
+		MaxDailyTrades: 1000,
+		OrderNotional:  100.0,
+	})
+}
+
+func makeHistory(prices ...float64) []strategy.MarketData {
+	out := make([]strategy.MarketData, len(prices))
+	for i, p := range prices {
+		out[i] = strategy.MarketData{Symbol: "BTC_JPY", Price: p}
+	}
+	return out
+}
+
+// TestCooldown_UsesSimulatedTime guarantees that cooldown elapses against the
+// observed MarketData.Timestamp rather than wall-clock time. Without this,
+// backtest replay (which processes long periods of ticks in seconds) would
+// trigger an indefinite "cooldown" HOLD after the very first BUY, producing
+// the well-known trade=1 plateau across all parameter combinations.
+func TestCooldown_UsesSimulatedTime(t *testing.T) {
+	s := newTestStrategy()
+	hist := makeHistory(100, 100, 100, 100, 100, 110, 120, 130, 140, 150)
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	// T=0: first signal call sets lastSeenTimestamp = base.
+	tick0 := &strategy.MarketData{Symbol: "BTC_JPY", Price: hist[len(hist)-1].Price, Timestamp: base}
+	if _, err := s.GenerateSignal(context.Background(), tick0, hist); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s.RecordTrade()
+
+	// T+1s: still in cooldown (300s).
+	tick1 := &strategy.MarketData{Symbol: "BTC_JPY", Price: hist[len(hist)-1].Price, Timestamp: base.Add(1 * time.Second)}
+	if _, err := s.GenerateSignal(context.Background(), tick1, hist); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !s.isInCooldown(300) {
+		t.Errorf("at +1s simulated: expected isInCooldown=true (cooldown=300s)")
+	}
+
+	// T+301s: cooldown elapsed in simulated time. Wall-clock-based code would
+	// still report cooldown here because only microseconds have actually passed.
+	tick2 := &strategy.MarketData{Symbol: "BTC_JPY", Price: hist[len(hist)-1].Price, Timestamp: base.Add(301 * time.Second)}
+	if _, err := s.GenerateSignal(context.Background(), tick2, hist); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.isInCooldown(300) {
+		t.Errorf("at +301s simulated: expected isInCooldown=false (cooldown elapsed)")
+	}
+}


### PR DESCRIPTION
## Summary
The `example/strategy/scalping` reference strategy gated cooldown and daily-limit on `time.Now()` / `time.Since()`. This works in live operation (where tick timestamps track wall-clock) but **breaks under backtest replay**: the simulator processes long stretches of historical ticks in seconds of wall-clock time, so the cooldown timer never elapses and only one BUY ever fires — the well-known **`trade=1` plateau** across all parameter combinations.

## Reproduction
Any backtest of this example strategy with `cooldown_sec > a few seconds` exhibits a sea of `reason: cooldown` HOLD signals after the first BUY. Grid optimization across hundreds of parameter combinations produces identical `trades=1` for every row, making the optimizer useless.

I hit this in a downstream project (`bmf-san/my-gogocoin`) and fixed the same pattern in three strategies; this PR back-ports the fix to the upstream example so other consumers don't fall into the same trap.

## Fix
- Track the most recently observed `MarketData.Timestamp` on the Strategy struct.
- `RecordTrade` / `isInCooldown` / `isDailyLimitReached` use that timestamp as "now", so cooldown elapses in simulated time during replay.
- Falls back to `time.Now()` when the observed timestamp is zero (preserves behavior for unit tests that don't set Timestamp).

## Live impact
**None.** In live operation, tick timestamps track wall-clock, so old and new code are observationally equivalent.

## Tests
Adds `TestCooldown_UsesSimulatedTime` as a regression guard: it asserts that `isInCooldown` returns true at simulated +1s and false at simulated +301s for a 300s cooldown, which the old `time.Now()` implementation cannot satisfy.

## Notes
- No changes to `pkg/strategy/scalping` (it has no cooldown feature).
- No public API changes.