### PR TITLE
feat(config): add trading.observe_symbols for data-collection-only subscriptions

### DIFF
--- a/internal/adapter/worker/strategy_worker.go
+++ b/internal/adapter/worker/strategy_worker.go
@@ -65,6 +65,12 @@ type StrategyWorker struct {
 
 	// positionReader is optional; when set, stop-loss is checked on every tick.
 	positionReader PositionReader
+
+	// tradeSymbols, when non-nil, restricts strategy processing to the given
+	// symbols. Market data for symbols outside this set is dropped before the
+	// strategy is invoked (observe-only / data-collection symbols). nil means
+	// "all incoming symbols" (legacy behavior).
+	tradeSymbols map[string]struct{}
 }
 
 // NewStrategyWorker creates a new strategy worker
@@ -88,6 +94,23 @@ func NewStrategyWorker(
 
 // Name returns the worker name.
 func (w *StrategyWorker) Name() string { return "strategy-worker" }
+
+// SetTradeSymbols restricts strategy processing to the given symbols.
+// Market data for other symbols (typically subscribed via observe_symbols
+// for data collection) is dropped before the strategy is invoked, so no
+// trade signals are produced for them. Passing nil or an empty slice
+// disables the filter and processes all incoming symbols.
+func (w *StrategyWorker) SetTradeSymbols(symbols []string) {
+	if len(symbols) == 0 {
+		w.tradeSymbols = nil
+		return
+	}
+	m := make(map[string]struct{}, len(symbols))
+	for _, s := range symbols {
+		m[s] = struct{}{}
+	}
+	w.tradeSymbols = m
+}
 
 // Run starts the strategy worker
 func (w *StrategyWorker) Run(ctx context.Context) error {
@@ -129,6 +152,15 @@ func (w *StrategyWorker) Run(ctx context.Context) error {
 			if !ok {
 				w.logger.Strategy().Info("Market data channel closed")
 				return nil
+			}
+
+			// Drop observe-only symbols before any per-tick work. Persistence
+			// happens in the exchange adapter independently, so historical data
+			// is still collected for these symbols.
+			if w.tradeSymbols != nil {
+				if _, ok := w.tradeSymbols[marketData.Symbol]; !ok {
+					continue
+				}
 			}
 
 			// Check context before spawning new goroutine

--- a/internal/adapter/worker/strategy_worker_observe_test.go
+++ b/internal/adapter/worker/strategy_worker_observe_test.go
@@ -1,0 +1,110 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bmf-san/gogocoin/internal/domain"
+	"github.com/bmf-san/gogocoin/internal/logger"
+	strategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+// observingStrategy records every Analyze call so the test can assert which
+// symbols the strategy actually saw.
+type observingStrategy struct {
+	mockStrategyWithConfig
+	seen chan string
+}
+
+func (s *observingStrategy) Analyze(data []strategy.MarketData) (*strategy.Signal, error) {
+	if len(data) > 0 {
+		select {
+		case s.seen <- data[len(data)-1].Symbol:
+		default:
+		}
+	}
+	return &strategy.Signal{Action: strategy.SignalHold}, nil
+}
+
+func TestStrategyWorker_SetTradeSymbols_FiltersObserveOnly(t *testing.T) {
+	log, err := logger.New(&logger.Config{
+		Level:    "error",
+		Format:   "json",
+		Output:   "file",
+		FilePath: "/dev/null",
+	})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+
+	strat := &observingStrategy{
+		mockStrategyWithConfig: mockStrategyWithConfig{cfg: map[string]any{}},
+		seen:                   make(chan string, 16),
+	}
+	marketDataCh := make(chan domain.MarketData, 8)
+	signalCh := make(chan *strategy.Signal, 16)
+	w := NewStrategyWorker(log, strat, marketDataCh, signalCh)
+	w.SetTradeSymbols([]string{"XRP_JPY"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = w.Run(ctx)
+		close(done)
+	}()
+
+	// Two ticks for the trade symbol, one for an observe-only symbol.
+	marketDataCh <- domain.MarketData{Symbol: "XRP_JPY", Price: 220, Timestamp: time.Now()}
+	marketDataCh <- domain.MarketData{Symbol: "MONA_JPY", Price: 14, Timestamp: time.Now()}
+	marketDataCh <- domain.MarketData{Symbol: "XRP_JPY", Price: 221, Timestamp: time.Now()}
+
+	// Give the worker time to drain the channel.
+	deadline := time.After(2 * time.Second)
+	gotXRP := 0
+	gotOther := 0
+loop:
+	for {
+		select {
+		case s := <-strat.seen:
+			if s == "XRP_JPY" {
+				gotXRP++
+				if gotXRP >= 2 {
+					break loop
+				}
+			} else {
+				gotOther++
+			}
+		case <-deadline:
+			break loop
+		}
+	}
+
+	cancel()
+	<-done
+
+	if gotXRP != 2 {
+		t.Errorf("expected XRP_JPY Analyze calls = 2, got %d", gotXRP)
+	}
+	if gotOther != 0 {
+		t.Errorf("expected observe-only symbol to be filtered, but strategy was invoked %d time(s) with non-trade symbol", gotOther)
+	}
+}
+
+func TestStrategyWorker_SetTradeSymbols_NilDisablesFilter(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{})
+	w.SetTradeSymbols([]string{"XRP_JPY"})
+	if w.tradeSymbols == nil {
+		t.Fatal("expected filter set after non-empty SetTradeSymbols")
+	}
+	w.SetTradeSymbols(nil)
+	if w.tradeSymbols != nil {
+		t.Errorf("expected nil filter after SetTradeSymbols(nil), got %v", w.tradeSymbols)
+	}
+	w.SetTradeSymbols([]string{})
+	if w.tradeSymbols != nil {
+		t.Errorf("expected nil filter after SetTradeSymbols(empty), got %v", w.tradeSymbols)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,11 @@ type TradingConfig struct {
 	FeeRate        float64              `yaml:"fee_rate"`
 	InitialBalance float64              `yaml:"initial_balance"`
 	Symbols        []string             `yaml:"symbols"`
+	// ObserveSymbols are subscribed to for market-data collection only.
+	// They are NOT fed to the strategy and never produce trade signals.
+	// Use this to warm up historical data for new symbols before promoting
+	// them into `symbols` for live trading.
+	ObserveSymbols []string             `yaml:"observe_symbols"`
 	Strategy       StrategyConfig       `yaml:"strategy"`
 	RiskManagement RiskManagementConfig `yaml:"risk_management"`
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -194,14 +194,20 @@ func run(ctx context.Context, cfg *config.Config, log logger.LoggerInterface, ec
 	// ── 10. Workers ───────────────────────────────────────────────────────────
 	clientFactory := &marketDataAdapter{client: bfClient, marketDataSvc: bfMarketDataSvc}
 
+	// Subscribe to trade symbols + observe-only symbols (data-collection only).
+	// Observe symbols are persisted to the DB by the exchange adapter but are
+	// filtered out before the strategy worker, so they never produce signals.
+	subscribeSymbols := mergeSymbols(cfg.Trading.Symbols, cfg.Trading.ObserveSymbols)
+
 	marketDataWorker := adapterworker.NewMarketDataWorker(
-		log, cfg.Trading.Symbols, marketDataCh, clientFactory,
+		log, subscribeSymbols, marketDataCh, clientFactory,
 		cfg.Worker.ReconnectIntervalSeconds,
 		cfg.Worker.MaxReconnectIntervalSeconds,
 		cfg.Worker.ConnectionCheckIntervalSeconds,
 		cfg.Worker.StaleDataTimeoutSeconds,
 	)
 	strategyWorker := adapterworker.NewStrategyWorker(log, strat, marketDataCh, signalCh)
+	strategyWorker.SetTradeSymbols(cfg.Trading.Symbols)
 	strategyWorker.SetPositionReader(repo)
 	signalWorker := adapterworker.NewSignalWorker(
 		log, signalCh, tradingCtrl, riskMgr, trader, strat, perfAnalytics,
@@ -256,6 +262,36 @@ func run(ctx context.Context, cfg *config.Config, log logger.LoggerInterface, ec
 
 	log.System().Info("gogocoin shut down successfully")
 	return nil
+}
+
+// mergeSymbols returns the union of two symbol lists, preserving the order of
+// `primary` first and appending any additional unique entries from `extra`.
+// Empty strings are skipped. Used to combine trade symbols with observe-only
+// symbols for a single WebSocket subscription pass.
+func mergeSymbols(primary, extra []string) []string {
+	seen := make(map[string]struct{}, len(primary)+len(extra))
+	out := make([]string, 0, len(primary)+len(extra))
+	for _, s := range primary {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	for _, s := range extra {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 // buildStrategy creates and initializes the strategy from the global registry.

--- a/pkg/engine/symbols_test.go
+++ b/pkg/engine/symbols_test.go
@@ -1,0 +1,48 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeSymbols(t *testing.T) {
+	tests := []struct {
+		name    string
+		primary []string
+		extra   []string
+		want    []string
+	}{
+		{"both empty", nil, nil, []string{}},
+		{"primary only", []string{"XRP_JPY", "XLM_JPY"}, nil, []string{"XRP_JPY", "XLM_JPY"}},
+		{"extra only", nil, []string{"MONA_JPY"}, []string{"MONA_JPY"}},
+		{
+			"union dedupes overlap",
+			[]string{"XRP_JPY", "XLM_JPY"},
+			[]string{"XLM_JPY", "MONA_JPY"},
+			[]string{"XRP_JPY", "XLM_JPY", "MONA_JPY"},
+		},
+		{
+			"skip empty entries",
+			[]string{"", "XRP_JPY"},
+			[]string{"", "MONA_JPY", ""},
+			[]string{"XRP_JPY", "MONA_JPY"},
+		},
+		{
+			"primary order preserved",
+			[]string{"B", "A"},
+			[]string{"C", "A"},
+			[]string{"B", "A", "C"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeSymbols(tt.primary, tt.extra)
+			if len(tt.want) == 0 && len(got) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeSymbols(%v, %v) = %v, want %v", tt.primary, tt.extra, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
新オプション `trading.observe_symbols` を追加。指定した銘柄に WebSocket 購読してデータ DB に蓄積するが、戦略には流さない (= 取引は発生しない)。

## Why
今は新銘柄を扱うには `trading.symbols` に入れるしかなく、historical data がゼロのまま即ライブで戦略を回す必要がある。これは backtest 不能 + 資金リスク両方が出る。

このフィールドを使えば、
1. `trading.observe_symbols: [MONA_JPY, ELF_JPY]` で 2〜3 週間データ収集
2. 蓄積後 `cmd/backtest optimize` で sweep
3. 採算ありなら `trading.symbols` に昇格

という安全なワークフローが可能になる。

## Changes
- `internal/config/config.go`: `TradingConfig.ObserveSymbols []string` 追加 (yaml: `observe_symbols`)
- `pkg/engine/engine.go`: `mergeSymbols(trade, observe)` で union を作って MarketDataWorker に渡し、`strategyWorker.SetTradeSymbols(cfg.Trading.Symbols)` でフィルタを設定
- `internal/adapter/worker/strategy_worker.go`:
  - `tradeSymbols map[string]struct{}` フィールド + `SetTradeSymbols([]string)` API
  - market_data 受信ループでセット外の symbol を `continue` でドロップ (history 追加も Analyze 呼び出しもしない)
- 永続化は `bitflyer.MarketDataService.saveMarketDataToDB` が購読ティック全てに対して既に走っているので、observe symbol も `data/gogocoin.db` に自動で蓄積される

## Behavior
- 既存設定 (observe_symbols 未指定) は完全な後方互換。`SetTradeSymbols(nil)` でフィルタ無効化
- validator は `trading.symbols` のみ iterate するため、observe symbol は balance / min_notional チェックを通らない (= 残高不足で起動失敗しない)

## Tests
- `pkg/engine/symbols_test.go`: `mergeSymbols` の union / dedup / 空エントリスキップ / 順序保持
- `internal/adapter/worker/strategy_worker_observe_test.go`: end-to-end で「XRP_JPY 2 ティック + MONA_JPY 1 ティック」を流し、Analyze が呼ばれるのは XRP のみであることを確認

## Test plan
- [x] `go build ./...` pass
- [x] `go test ./pkg/engine/... ./internal/adapter/worker/... ./internal/config/...` pass
- [ ] merge 後 my-gogocoin の `go.mod` を bump → MONA/ELF を `observe_symbols` に追加して deploy
