### PR TITLE
feat(worker): bar aggregation for strategy worker

### DIFF
--- a/internal/adapter/worker/strategy_worker.go
+++ b/internal/adapter/worker/strategy_worker.go
@@ -33,6 +33,19 @@ type symbolHistory struct {
 	data       []strategy.MarketData
 	lastAccess time.Time
 	mu         sync.RWMutex
+
+	// Bar aggregation state. Used only when StrategyWorker.barPeriod > 0.
+	// When in bar-aggregation mode, `data` above holds COMPLETED BARS
+	// (one MarketData per finalized bar, Price=Close, Timestamp=bucket start)
+	// rather than raw ticks.
+	barOpen    bool
+	barStart   time.Time
+	barHigh    float64
+	barLow     float64
+	barClose   float64
+	barVolume  float64
+	barBestBid float64
+	barBestAsk float64
 }
 
 // StrategyWorker processes market data and generates trading signals
@@ -44,6 +57,7 @@ type StrategyWorker struct {
 	historyLimit       int
 	maxSymbols         int           // Maximum number of symbols to track
 	symbolExpiryPeriod time.Duration // Period after which inactive symbols are removed
+	barPeriod          time.Duration // When > 0, aggregate ticks into bars of this length and invoke strategy on bar close only.
 
 	// Symbol histories with per-symbol locking for better concurrency
 	histories sync.Map // map[string]*symbolHistory
@@ -94,6 +108,34 @@ func NewStrategyWorker(
 
 // Name returns the worker name.
 func (w *StrategyWorker) Name() string { return "strategy-worker" }
+
+// SetBarPeriod configures bar aggregation. When period > 0, the worker
+// aggregates incoming ticks into UTC-aligned OHLCV bars of the given length
+// and invokes the strategy once per completed bar (instead of on every tick).
+// The bar's Close becomes MarketData.Price exposed to the strategy. Stop-loss
+// and take-profit checks continue to run on every tick. Calling with 0 or a
+// negative value disables aggregation (legacy per-tick behavior). Safe to
+// call before Run().
+func (w *StrategyWorker) SetBarPeriod(period time.Duration) {
+	if period < 0 {
+		period = 0
+	}
+	w.barPeriod = period
+}
+
+// barBucketStart returns the UTC-aligned start of the bucket containing t for
+// the given period. Mirrors the resampling logic used by the backtest engine
+// so that live bar boundaries match backtest bar boundaries exactly.
+func barBucketStart(t time.Time, period time.Duration) time.Time {
+	u := t.UTC()
+	ns := u.UnixNano()
+	bucketNs := period.Nanoseconds()
+	startNs := ns - (ns % bucketNs)
+	if ns < 0 && ns%bucketNs != 0 {
+		startNs -= bucketNs
+	}
+	return time.Unix(0, startNs).UTC()
+}
 
 // SetTradeSymbols restricts strategy processing to the given symbols.
 // Market data for other symbols (typically subscribed via observe_symbols
@@ -168,6 +210,16 @@ func (w *StrategyWorker) Run(ctx context.Context) error {
 			case <-ctx.Done():
 				return nil
 			default:
+			}
+
+			// In bar-aggregation mode, process ticks synchronously in the
+			// main loop to preserve FIFO ordering per symbol. Bar updates
+			// and forced-exit checks are microsecond-scale operations, so
+			// the throughput cost is negligible compared to the correctness
+			// gain (out-of-order tick processing would corrupt OHLCV bars).
+			if w.barPeriod > 0 {
+				w.processTickBarMode(ctx, &marketData)
+				continue
 			}
 
 			// Process market data asynchronously to prevent blocking the channel
@@ -397,6 +449,161 @@ func (w *StrategyWorker) checkTakeProfit(symbol string, currentPrice float64) *s
 		}
 	}
 	return nil
+}
+
+// processTickBarMode handles a single market data tick when bar aggregation
+// is enabled (BarPeriod > 0). Called synchronously from the main Run loop to
+// guarantee per-symbol FIFO ordering, which is essential for correct OHLCV
+// aggregation. Ticks whose timestamps fall before the currently-open bucket
+// are treated as stale and dropped from aggregation (but SL/TP still runs).
+func (w *StrategyWorker) processTickBarMode(ctx context.Context, data *domain.MarketData) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.logger.Strategy().WithField("panic", r).Error("Bar-mode tick processing panicked")
+		}
+	}()
+
+	strategyData := strategy.MarketData{
+		Symbol:    data.Symbol,
+		Price:     data.Price,
+		Volume:    data.Volume,
+		BestBid:   data.BestBid,
+		BestAsk:   data.BestAsk,
+		Spread:    data.Spread,
+		Timestamp: data.Timestamp,
+	}
+
+	hist := w.getOrCreateHistory(data.Symbol)
+	bucket := barBucketStart(strategyData.Timestamp, w.barPeriod)
+
+	hist.mu.Lock()
+	var completedBar *strategy.MarketData
+	switch {
+	case !hist.barOpen:
+		hist.barOpen = true
+		hist.barStart = bucket
+		hist.barHigh = strategyData.Price
+		hist.barLow = strategyData.Price
+		hist.barClose = strategyData.Price
+		hist.barVolume = strategyData.Volume
+		hist.barBestBid = strategyData.BestBid
+		hist.barBestAsk = strategyData.BestAsk
+	case bucket.Equal(hist.barStart):
+		if strategyData.Price > hist.barHigh {
+			hist.barHigh = strategyData.Price
+		}
+		if strategyData.Price < hist.barLow {
+			hist.barLow = strategyData.Price
+		}
+		hist.barClose = strategyData.Price
+		hist.barVolume += strategyData.Volume
+		hist.barBestBid = strategyData.BestBid
+		hist.barBestAsk = strategyData.BestAsk
+	case bucket.After(hist.barStart):
+		// Finalize the prior bar.
+		bar := strategy.MarketData{
+			Symbol:    data.Symbol,
+			Price:     hist.barClose,
+			Volume:    hist.barVolume,
+			BestBid:   hist.barBestBid,
+			BestAsk:   hist.barBestAsk,
+			Spread:    hist.barBestAsk - hist.barBestBid,
+			Timestamp: hist.barStart,
+		}
+		completedBar = &bar
+		hist.data = append(hist.data, bar)
+		if len(hist.data) > w.historyLimit {
+			hist.data = hist.data[len(hist.data)-w.historyLimit:]
+		}
+		// Open a new bucket from the current tick.
+		hist.barStart = bucket
+		hist.barHigh = strategyData.Price
+		hist.barLow = strategyData.Price
+		hist.barClose = strategyData.Price
+		hist.barVolume = strategyData.Volume
+		hist.barBestBid = strategyData.BestBid
+		hist.barBestAsk = strategyData.BestAsk
+	default:
+		// bucket.Before(hist.barStart) — stale out-of-order tick; ignore
+		// for aggregation. Risk-management still runs on the tick price.
+	}
+	hist.lastAccess = time.Now()
+	var historyCopy []strategy.MarketData
+	if completedBar != nil {
+		historyCopy = make([]strategy.MarketData, len(hist.data))
+		copy(historyCopy, hist.data)
+	}
+	hist.mu.Unlock()
+
+	// Risk management always runs on the live tick price, even when no bar
+	// finalizes on this tick.
+	w.dispatchForcedExitIfAny(ctx, data)
+
+	if completedBar == nil {
+		return
+	}
+
+	barDomain := domain.MarketData{
+		Symbol:    completedBar.Symbol,
+		Price:     completedBar.Price,
+		Volume:    completedBar.Volume,
+		BestBid:   completedBar.BestBid,
+		BestAsk:   completedBar.BestAsk,
+		Spread:    completedBar.Spread,
+		Timestamp: completedBar.Timestamp,
+	}
+	w.logger.Strategy().
+		WithField("symbol", data.Symbol).
+		WithField("bar_close", completedBar.Price).
+		WithField("history_count", len(historyCopy)).
+		Debug("Bar finalized, invoking strategy")
+	w.executeStrategy(ctx, &barDomain, historyCopy)
+}
+
+// dispatchForcedExitIfAny checks SL/TP on the current tick and emits a SELL
+// signal if either is triggered. Used in bar-aggregation mode where strategy
+// signals are produced only on bar close, but risk-management exits must
+// remain tick-level. The per-symbol ForcedExitCooldown prevents flooding
+// when an order is still settling.
+func (w *StrategyWorker) dispatchForcedExitIfAny(ctx context.Context, marketData *domain.MarketData) {
+	var sig *strategy.Signal
+	if s := w.checkStopLoss(marketData.Symbol, marketData.Price); s != nil {
+		sig = s
+	} else if s := w.checkTakeProfit(marketData.Symbol, marketData.Price); s != nil {
+		sig = s
+	}
+	if sig == nil {
+		return
+	}
+	if last, ok := w.lastForcedExitAttempt.Load(sig.Symbol); ok {
+		if time.Since(last.(time.Time)) < ForcedExitCooldown {
+			return
+		}
+	}
+	// Clear standard dedup so a stale BUY/SELL doesn't block the forced exit.
+	w.lastSentSignals.Delete(sig.Symbol)
+
+	w.logger.LogStrategySignal(
+		w.strategy.Name(),
+		sig.Symbol,
+		string(sig.Action),
+		sig.Strength,
+		sig.Metadata,
+	)
+	select {
+	case w.signalCh <- sig:
+		w.lastSentSignals.Store(sig.Symbol, sig.Action)
+		w.lastForcedExitAttempt.Store(sig.Symbol, time.Now())
+	case <-ctx.Done():
+		return
+	default:
+		droppedCount := atomic.AddInt64(&w.droppedSignals, 1)
+		w.logger.Strategy().
+			WithField("dropped_count", droppedCount).
+			WithField("symbol", sig.Symbol).
+			WithField("action", sig.Action).
+			Warn("Signal channel is full, dropping forced-exit signal")
+	}
 }
 
 // executeStrategy executes the strategy

--- a/internal/adapter/worker/strategy_worker_bar_test.go
+++ b/internal/adapter/worker/strategy_worker_bar_test.go
@@ -1,0 +1,192 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bmf-san/gogocoin/internal/domain"
+	"github.com/bmf-san/gogocoin/internal/logger"
+	strategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+// recordingStrategy captures every Analyze() call for assertion in tests.
+// It embeds the package-level mockStrategy to inherit the no-op
+// implementations of the rest of the Strategy interface.
+type recordingStrategy struct {
+	mockStrategy
+	mu    sync.Mutex
+	calls [][]strategy.MarketData
+}
+
+func (r *recordingStrategy) Analyze(data []strategy.MarketData) (*strategy.Signal, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]strategy.MarketData, len(data))
+	copy(cp, data)
+	r.calls = append(r.calls, cp)
+	return &strategy.Signal{Action: strategy.SignalHold}, nil
+}
+
+func (r *recordingStrategy) snapshot() [][]strategy.MarketData {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]strategy.MarketData, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// TestBarBucketStart verifies UTC alignment of bar buckets matches the
+// backtest resampler's expectations (left-labeled, UTC-aligned).
+func TestBarBucketStart(t *testing.T) {
+	hour := time.Hour
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"2026-05-26T03:14:59Z", "2026-05-26T03:00:00Z"},
+		{"2026-05-26T03:00:00Z", "2026-05-26T03:00:00Z"},
+		{"2026-05-26T03:59:59.999Z", "2026-05-26T03:00:00Z"},
+	}
+	for _, c := range cases {
+		ts, _ := time.Parse(time.RFC3339Nano, c.in)
+		got := barBucketStart(ts, hour).Format(time.RFC3339Nano)
+		want, _ := time.Parse(time.RFC3339Nano, c.want)
+		if got != want.Format(time.RFC3339Nano) {
+			t.Errorf("barBucketStart(%s) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+// TestStrategyWorker_BarAggregation_InvokesPerBar feeds ticks spanning three
+// 1-minute buckets and verifies Analyze is invoked exactly twice (once per
+// completed bar — the still-open final bar is not flushed) and that history
+// passed to Analyze contains aggregated bars, not raw ticks.
+func TestStrategyWorker_BarAggregation_InvokesPerBar(t *testing.T) {
+	log, err := logger.New(&logger.Config{
+		Level: "error", Format: "json", Output: "file", FilePath: "/dev/null",
+	})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+
+	rec := &recordingStrategy{}
+	dataCh := make(chan domain.MarketData, 16)
+	sigCh := make(chan *strategy.Signal, 16)
+	w := NewStrategyWorker(log, rec, dataCh, sigCh)
+	w.SetBarPeriod(time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = w.Run(ctx)
+		close(done)
+	}()
+
+	base := time.Date(2026, 5, 26, 3, 0, 0, 0, time.UTC)
+	ticks := []domain.MarketData{
+		// Bucket A (03:00): three ticks, close=101
+		{Symbol: "XRP_JPY", Price: 100, Timestamp: base.Add(10 * time.Second)},
+		{Symbol: "XRP_JPY", Price: 102, Timestamp: base.Add(30 * time.Second)},
+		{Symbol: "XRP_JPY", Price: 101, Timestamp: base.Add(50 * time.Second)},
+		// Bucket B (03:01): two ticks, close=104
+		{Symbol: "XRP_JPY", Price: 103, Timestamp: base.Add(70 * time.Second)},
+		{Symbol: "XRP_JPY", Price: 104, Timestamp: base.Add(90 * time.Second)},
+		// Bucket C (03:02): one tick, close=105 — opens bar but does not finalize it
+		{Symbol: "XRP_JPY", Price: 105, Timestamp: base.Add(130 * time.Second)},
+	}
+	for _, m := range ticks {
+		dataCh <- m
+	}
+
+	// Wait for at most ~2 s for the worker to drain ticks and finalize two bars.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(rec.snapshot()) >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	calls := rec.snapshot()
+	if len(calls) != 2 {
+		t.Fatalf("expected exactly 2 Analyze calls (one per completed bar), got %d", len(calls))
+	}
+
+	// First call: only Bucket A bar in history, Close=101.
+	if got := len(calls[0]); got != 1 {
+		t.Errorf("first call history len = %d, want 1", got)
+	} else if calls[0][0].Price != 101 {
+		t.Errorf("first bar Close = %v, want 101", calls[0][0].Price)
+	}
+	// Second call: Bucket A + Bucket B, Bucket B Close=104.
+	if got := len(calls[1]); got != 2 {
+		t.Errorf("second call history len = %d, want 2", got)
+	} else {
+		if calls[1][0].Price != 101 {
+			t.Errorf("history[0].Price = %v, want 101", calls[1][0].Price)
+		}
+		if calls[1][1].Price != 104 {
+			t.Errorf("history[1].Price = %v, want 104", calls[1][1].Price)
+		}
+	}
+	// Timestamps should be bucket starts (left-labeled).
+	wantStart := base
+	if !calls[1][0].Timestamp.Equal(wantStart) {
+		t.Errorf("bar A timestamp = %v, want %v", calls[1][0].Timestamp, wantStart)
+	}
+	if !calls[1][1].Timestamp.Equal(base.Add(time.Minute)) {
+		t.Errorf("bar B timestamp = %v, want %v", calls[1][1].Timestamp, base.Add(time.Minute))
+	}
+
+	cancel()
+	close(dataCh)
+	<-done
+}
+
+// TestStrategyWorker_BarAggregation_Disabled verifies that with BarPeriod=0
+// (default) the worker preserves legacy per-tick behavior: every tick
+// triggers an Analyze call.
+func TestStrategyWorker_BarAggregation_Disabled(t *testing.T) {
+	log, err := logger.New(&logger.Config{
+		Level: "error", Format: "json", Output: "file", FilePath: "/dev/null",
+	})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+
+	rec := &recordingStrategy{}
+	dataCh := make(chan domain.MarketData, 8)
+	sigCh := make(chan *strategy.Signal, 8)
+	w := NewStrategyWorker(log, rec, dataCh, sigCh)
+	// Note: SetBarPeriod NOT called → tick mode.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = w.Run(ctx)
+		close(done)
+	}()
+
+	base := time.Date(2026, 5, 26, 3, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		dataCh <- domain.MarketData{Symbol: "XRP_JPY", Price: 100 + float64(i), Timestamp: base.Add(time.Duration(i) * time.Second)}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(rec.snapshot()) >= 3 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if got := len(rec.snapshot()); got != 3 {
+		t.Errorf("expected 3 per-tick Analyze calls, got %d", got)
+	}
+
+	cancel()
+	close(dataCh)
+	<-done
+}

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -54,6 +54,16 @@ type StrategyWorkerConfig struct {
 
 	// History retention
 	HistoryRetentionHours int `yaml:"history_retention_hours"`
+
+	// BarPeriod, when > 0, causes the strategy worker to aggregate incoming
+	// market data ticks into time-aligned OHLCV bars (UTC-aligned) of this
+	// length and invoke the strategy once per completed bar instead of on
+	// every tick. The bar's Close price is exposed to the strategy as the
+	// MarketData.Price for both the latest data point and each history
+	// entry. Stop-loss and take-profit checks continue to run on every tick.
+	// When 0 (the default) the worker uses the legacy per-tick behavior and
+	// passes raw ticks through to the strategy unchanged.
+	BarPeriod time.Duration `yaml:"bar_period"`
 }
 
 // MaintenanceWorkerConfig represents maintenance worker configuration

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -208,6 +208,7 @@ func run(ctx context.Context, cfg *config.Config, log logger.LoggerInterface, ec
 	)
 	strategyWorker := adapterworker.NewStrategyWorker(log, strat, marketDataCh, signalCh)
 	strategyWorker.SetTradeSymbols(cfg.Trading.Symbols)
+	strategyWorker.SetBarPeriod(cfg.Worker.Strategy.BarPeriod)
 	strategyWorker.SetPositionReader(repo)
 	signalWorker := adapterworker.NewSignalWorker(
 		log, signalCh, tradingCtrl, riskMgr, trader, strat, perfAnalytics,


### PR DESCRIPTION
feat(worker): bar aggregation for strategy worker

Adds an opt-in bar-aggregation mode to StrategyWorker so that strategies
designed against 1h (or any) OHLCV bars in the backtest engine can be
executed unchanged in live trading.

When `worker.strategy.bar_period` is set to a positive duration (e.g.
`1h`), the worker:

- Aggregates incoming ticks into UTC-aligned OHLCV buckets that match
  the backtest engine's `ResamplingDatasource` boundaries exactly.
- Holds a per-symbol bar accumulator (open/high/low/close/volume +
  latest best bid/ask) protected by the existing per-symbol mutex.
- On a bucket-transition tick, finalizes the prior bar, appends it to
  the strategy history as a single MarketData{Price=Close,
  Timestamp=bucket start}, then invokes `strategy.Analyze` exactly once
  on the resulting bar history.
- Drops stale out-of-order ticks (bucket < open bucket) from
  aggregation so a late tick cannot corrupt OHLC of a newer bar.
- Runs stop-loss / take-profit checks on every tick (not just bar
  close) so risk management remains tick-level.
- In bar mode, processes ticks synchronously in the main loop to
  guarantee per-symbol FIFO ordering. (The microsecond-scale work
  cost is dwarfed by the correctness gain — out-of-order goroutine
  scheduling under the existing processing pool was observed to
  corrupt OHLC during tests.)

When `bar_period` is 0 (the default) the legacy per-tick behavior is
fully preserved: every tick still invokes the strategy, the async
processing pool is still used, and existing tick-mode strategies
(e.g. scalping) are unaffected.

Tests:
- `TestBarBucketStart` — verifies UTC alignment matches resampler.
- `TestStrategyWorker_BarAggregation_InvokesPerBar` — feeds ticks
  across three 1-minute buckets and verifies exactly two finalized
  bar invocations with correct Close prices and bucket-start
  timestamps.
- `TestStrategyWorker_BarAggregation_Disabled` — verifies the
  legacy per-tick mode is unchanged when BarPeriod is left at 0.

All existing tests pass (incl. `-race`).

Motivation: enables deploying the swing_meanrev XRP candidate
discovered in the OOS widesweep research (my-gogocoin PR #230),
where 1h-bar backtest produced +377 JPY / 58 d (winrate 80%, PF 1.93).
