### PR TITLE
feat(backtest): add shared backtest engine and CLI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,8 @@ linters:
       - ".*\\.pb\\.go"
       - "testdata/.*"
     rules:
+      - path: "^pkg/backtest/.*\\.go$"
+        linters: [gocritic]         # backtest core import: keep runtime checks, relax style-only copies
       - path: "_test\\.go"
         linters: [gocritic, errcheck]  # test files: gocritic & errcheck suppressed
       - path: "_test\\.go"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # gogocoin Makefile
 
-.PHONY: help init test test-race test-coverage fmt fmt-check lint tidy-check vuln deps install-tools generate generate-check clean
+.PHONY: help init test test-race test-coverage fmt fmt-check lint tidy-check vuln deps install-tools generate generate-check backtest backtest-grid backtest-walkforward clean
 
 # Default target
 .DEFAULT_GOAL := help
@@ -89,6 +89,20 @@ generate-check: generate ## Verify generated code is in sync with OpenAPI spec (
 		exit 1; \
 	fi
 	@echo "Generated code is up-to-date."
+
+# Backtest
+BACKTEST_SCENARIO ?= scalping_xrp_default
+BACKTEST_OUT      ?= out/backtest
+BACKTEST_CONFIG   ?= configs/backtest.yaml
+
+backtest: ## Run a single backtest scenario (BACKTEST_SCENARIO=name)
+	@go run ./cmd/backtest run --config $(BACKTEST_CONFIG) --scenario $(BACKTEST_SCENARIO) --out $(BACKTEST_OUT)
+
+backtest-grid: ## Grid search optimisation (BACKTEST_SCENARIO=name with grid block)
+	@go run ./cmd/backtest optimize --config $(BACKTEST_CONFIG) --scenario $(BACKTEST_SCENARIO) --out out/optimize
+
+backtest-walkforward: ## Walk-forward analysis
+	@go run ./cmd/backtest walkforward --config $(BACKTEST_CONFIG) --scenario $(BACKTEST_SCENARIO) --out out/walkforward
 
 # Cleanup
 clean: ## Clean build artifacts and test cache

--- a/cmd/backtest/main.go
+++ b/cmd/backtest/main.go
@@ -1,0 +1,82 @@
+// Command backtest is the gogocoin CLI for offline strategy validation.
+//
+// Subcommands:
+//   - run         Single scenario backtest.
+//   - optimize    Grid search over scenario.grid → CSV ranking.
+//   - walkforward In-sample / out-of-sample analysis.
+//   - compare     Run multiple scenarios and write a comparison CSV.
+//
+// All subcommands read configs/backtest.yaml by default.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/bmf-san/gogocoin/pkg/backtest/cli"
+
+	// Register strategies via blank imports.
+	_ "github.com/bmf-san/gogocoin/pkg/strategy/scalping"
+)
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	if len(os.Args) < 2 {
+		usage()
+		return 2
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() { <-sigCh; cancel() }()
+
+	cmd := os.Args[1]
+	args := os.Args[2:]
+	var err error
+	switch cmd {
+	case "run":
+		err = cli.Run(ctx, args)
+	case "optimize":
+		err = cli.Optimize(ctx, args)
+	case "walkforward":
+		err = cli.WalkForward(ctx, args)
+	case "compare":
+		err = cli.Compare(ctx, args)
+	case "-h", "--help", "help":
+		usage()
+		return 0
+	default:
+		_, _ = fmt.Fprintf(os.Stderr, "unknown command %q\n", cmd)
+		usage()
+		return 2
+	}
+	if err == nil {
+		return 0
+	}
+	if err == flag.ErrHelp {
+		return 0
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	return 1
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, `backtest — offline strategy validation
+
+Usage:
+  backtest <command> [flags]
+
+Commands:
+  run         Run a single scenario.
+  optimize    Grid search over a scenario's grid block.
+  walkforward Walk-forward analysis (train/test rolling windows).
+  compare     Run multiple scenarios and produce a comparison CSV.
+
+Run "backtest <command> -h" for command-specific flags.`)
+}

--- a/configs/backtest.yaml
+++ b/configs/backtest.yaml
@@ -1,0 +1,65 @@
+# Minimal backtest scenarios for gogocoin.
+
+data:
+  source: sqlite
+  path: data/gogocoin.db
+  symbol: BTC_JPY
+  from: ""
+  to: ""
+
+simulator:
+  initial_balance: 100000
+  fee_rate: 0.0015
+  slippage_bps: 5
+  same_bar_rule: sl_priority
+  min_volume_ratio: 0
+
+scenarios:
+  scalping_xrp_default:
+    strategy: scalping
+    data_override:
+      symbol: XRP_JPY
+    params:
+      ema_fast_period: 12
+      ema_slow_period: 26
+      ema_spread_threshold_pct: 0.025
+      take_profit_pct: 1.2
+      stop_loss_pct: 0.5
+      cooldown_sec: 1800
+      max_daily_trades: 3
+      order_notional: 3000
+      fee_rate: 0.0015
+      rsi_period: 14
+      rsi_overbought: 65.0
+      rsi_oversold: 35.0
+      trend_filter_enabled: true
+      trend_ema_period: 100
+      atr_period: 20
+      atr_min_pct: 0.05
+      atr_max_pct: 1.2
+      entry_confirmation_ticks: 3
+
+  scalping_xrp_grid:
+    strategy: scalping
+    data_override:
+      symbol: XRP_JPY
+    grid:
+      ema_fast_period: [8, 12, 15, 20]
+      ema_slow_period: [21, 26, 35, 50]
+      take_profit_pct: [0.6, 1.0, 1.2, 1.5]
+      stop_loss_pct: [0.4, 0.6, 0.8]
+    fixed:
+      ema_spread_threshold_pct: 0.025
+      cooldown_sec: 1800
+      max_daily_trades: 10
+      order_notional: 3000
+      fee_rate: 0.0015
+      rsi_period: 14
+      rsi_overbought: 65.0
+      rsi_oversold: 35.0
+      trend_filter_enabled: true
+      trend_ema_period: 100
+      atr_period: 20
+      atr_min_pct: 0.05
+      atr_max_pct: 1.2
+      entry_confirmation_ticks: 3

--- a/docs/BACKTEST.md
+++ b/docs/BACKTEST.md
@@ -1,0 +1,36 @@
+# Backtest
+
+Backtesting in gogocoin is implemented in a reusable package and CLI:
+
+- Core package: `pkg/backtest`
+- CLI command: `cmd/backtest`
+
+## Quick Start
+
+```bash
+# Single scenario
+make backtest
+
+# Grid optimization
+make backtest-grid BACKTEST_SCENARIO=scalping_xrp_grid
+
+# Walk-forward analysis
+make backtest-walkforward BACKTEST_SCENARIO=scalping_xrp_grid
+```
+
+Default config is `configs/backtest.yaml`.
+
+## CLI
+
+```bash
+go run ./cmd/backtest run -h
+go run ./cmd/backtest optimize -h
+go run ./cmd/backtest walkforward -h
+go run ./cmd/backtest compare -h
+```
+
+## Notes
+
+- Uses the same strategy registry in `pkg/strategy`.
+- `scalping` is registered via blank import in `cmd/backtest/main.go`.
+- Data source supports SQLite and CSV based on the backtest config.

--- a/example/go.mod
+++ b/example/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/lerenn/asyncapi-codegen v0.46.3 // indirect
 	github.com/mattn/go-sqlite3 v1.14.44 // indirect
-	github.com/oapi-codegen/runtime v1.4.0 // indirect
+	github.com/oapi-codegen/runtime v1.4.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/example/go.sum
+++ b/example/go.sum
@@ -20,8 +20,10 @@ github.com/lerenn/asyncapi-codegen v0.46.3 h1:lw1Iou6FTwMYZN6QiZNwsZl0o7sbWl5KZe
 github.com/lerenn/asyncapi-codegen v0.46.3/go.mod h1:vXZMzuQOCB4Owi2CzF08jMrs8XZ055+ulBrPODX3jzQ=
 github.com/mattn/go-sqlite3 v1.14.44 h1:3VSe+xafpbzsLbdr2AWlAZk9yRHiBhTBakioXaCKTF8=
 github.com/mattn/go-sqlite3 v1.14.44/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kbHKBr7yXKVQ=
-github.com/oapi-codegen/runtime v1.4.0 h1:KLOSFOp7UzkbS7Cs1ms6NBEKYr0WmH2wZG0KKbd2er4=
-github.com/oapi-codegen/runtime v1.4.0/go.mod h1:5sw5fxCDmnOzKNYmkVNF8d34kyUeejJEY8HNT2WaPec=
+github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
+github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
+github.com/oapi-codegen/runtime v1.4.1 h1:9nwLoI+KrWxzbBcp0jO/R8uXqbik/HUyCvPeU68Y/qo=
+github.com/oapi-codegen/runtime v1.4.1/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/pkg/backtest/cli/cli.go
+++ b/pkg/backtest/cli/cli.go
@@ -1,0 +1,146 @@
+package cli
+
+// Package cli implements the backtest CLI subcommands.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/bmf-san/gogocoin/pkg/backtest"
+	pkgstrategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+// buildDatasource constructs a Datasource from cfg overlaid with optional
+// from/to overrides (used by walk-forward). If cfg.BarPeriod is set, the
+// raw datasource is wrapped in a ResamplingDatasource.
+func buildDatasource(cfg backtest.DataConfig, fromOverride, toOverride time.Time) (backtest.Datasource, error) {
+	from, err := backtest.ParseDate(cfg.From)
+	if err != nil {
+		return nil, fmt.Errorf("data.from: %w", err)
+	}
+	to, err := backtest.ParseDate(cfg.To)
+	if err != nil {
+		return nil, fmt.Errorf("data.to: %w", err)
+	}
+	if !fromOverride.IsZero() {
+		from = fromOverride
+	}
+	if !toOverride.IsZero() {
+		to = toOverride
+	}
+	period, err := backtest.ParseBarPeriod(cfg.BarPeriod)
+	if err != nil {
+		return nil, fmt.Errorf("data.bar_period: %w", err)
+	}
+	var inner backtest.Datasource
+	switch cfg.Source {
+	case "", "sqlite":
+		inner, err = backtest.NewSQLiteDatasource(backtest.SQLiteDatasourceOptions{
+			Path:   cfg.Path,
+			Symbol: cfg.Symbol,
+			From:   from,
+			To:     to,
+		})
+	case "csv":
+		inner, err = backtest.NewCSVDatasource(backtest.CSVDatasourceOptions{
+			Path:   cfg.Path,
+			Symbol: cfg.Symbol,
+			From:   from,
+			To:     to,
+		})
+	default:
+		return nil, fmt.Errorf("unknown data.source %q", cfg.Source)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if period > 0 {
+		return backtest.NewResamplingDatasource(inner, period)
+	}
+	return inner, nil
+}
+
+// buildStrategy creates an initialized Strategy from a scenario.
+func buildStrategy(name string, params map[string]interface{}) (pkgstrategy.Strategy, error) {
+	s, err := pkgstrategy.Create(name)
+	if err != nil {
+		return nil, fmt.Errorf("strategy %q: %w", name, err)
+	}
+	if params != nil {
+		if err := s.Initialize(params); err != nil {
+			return nil, fmt.Errorf("initialize: %w", err)
+		}
+	}
+	if err := s.Reset(); err != nil {
+		return nil, fmt.Errorf("reset: %w", err)
+	}
+	return s, nil
+}
+
+// runScenario is the shared inner loop for `run` and `compare`.
+func runScenario(ctx context.Context, cfg *backtest.Config, scenarioName string,
+	from, to time.Time, paramsOverride map[string]interface{},
+	outDir string, quiet bool,
+) (*backtest.Result, error) {
+	sc, ok := cfg.Scenarios[scenarioName]
+	if !ok {
+		return nil, fmt.Errorf("scenario %q not found", scenarioName)
+	}
+	params := mergeParams(sc.Params, paramsOverride)
+	strat, err := buildStrategy(sc.Strategy, params)
+	if err != nil {
+		return nil, err
+	}
+	ds, err := buildDatasource(sc.DataOverride.Apply(cfg.Data), from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer ds.Close()
+	res, err := backtest.NewEngine(backtest.EngineConfig{
+		Strategy:     strat,
+		Datasource:   ds,
+		Simulator:    cfg.Simulator.ToSimulatorConfig(),
+		HistoryLimit: sc.HistoryLimit,
+	}).Run(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if outDir != "" {
+		if err := backtest.WriteCSVReports(outDir, res); err != nil {
+			return nil, fmt.Errorf("write reports: %w", err)
+		}
+	}
+	if !quiet {
+		backtest.PrintSummary(os.Stdout, res)
+	}
+	return res, nil
+}
+
+func mergeParams(base, overlay map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(base)+len(overlay))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range overlay {
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// outDirOrEmpty resolves a possibly-relative output dir.
+func outDirOrEmpty(s string) string {
+	if s == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(s)
+	if err != nil {
+		return s
+	}
+	return abs
+}

--- a/pkg/backtest/cli/compare.go
+++ b/pkg/backtest/cli/compare.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bmf-san/gogocoin/pkg/backtest"
+)
+
+// Compare implements `backtest compare`.
+//
+// Runs N scenarios against the same data range and writes a comparison CSV.
+func Compare(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("compare", flag.ContinueOnError)
+	configPath := fs.String("config", "configs/backtest.yaml", "path to backtest YAML config")
+	scenarios := fs.String("scenarios", "", "comma-separated scenario names (required)")
+	out := fs.String("out", "out/compare", "output directory")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *scenarios == "" {
+		fs.Usage()
+		return flag.ErrHelp
+	}
+	cfg, err := backtest.LoadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	names := splitTrim(*scenarios)
+	type row struct {
+		name string
+		res  *backtest.Result
+	}
+	rows := make([]row, 0, len(names))
+	for _, name := range names {
+		r, err := runScenario(ctx, cfg, name, time.Time{}, time.Time{}, nil,
+			filepath.Join(*out, name), false)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "scenario %q failed: %v\n", name, err)
+			continue
+		}
+		rows = append(rows, row{name: name, res: r})
+		fmt.Println()
+	}
+	if err := os.MkdirAll(*out, 0o755); err != nil {
+		return err
+	}
+	csvPath := filepath.Join(*out, "summary.csv")
+	f, err := os.Create(csvPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	if err := w.Write([]string{"scenario", "trades", "win_rate", "net_pnl",
+		"profit_factor", "max_dd_pct", "sharpe", "sortino", "fees", "slippage"}); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		s := r.res.Summary
+		if err := w.Write([]string{
+			r.name,
+			strconv.Itoa(s.TotalTrades),
+			fmtFloat(s.WinRate),
+			fmtFloat(s.NetPnL),
+			fmtFloat(s.ProfitFactor),
+			fmtFloat(s.MaxDrawdown * 100),
+			fmtFloat(s.SharpeAnnualised),
+			fmtFloat(s.Sortino),
+			fmtFloat(s.TotalFees),
+			fmtFloat(s.TotalSlippage),
+		}); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s\n", csvPath)
+	return nil
+}
+
+func splitTrim(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/pkg/backtest/cli/optimize.go
+++ b/pkg/backtest/cli/optimize.go
@@ -1,0 +1,214 @@
+package cli
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/bmf-san/gogocoin/pkg/backtest"
+)
+
+// Optimize implements `backtest optimize`.
+//
+// It expands scenarios[name].grid into the cartesian product, runs each
+// combination, and writes a ranking CSV (one row per combination).
+func Optimize(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("optimize", flag.ContinueOnError)
+	configPath := fs.String("config", "configs/backtest.yaml", "path to backtest YAML config")
+	scenario := fs.String("scenario", "", "scenario name (required, must define a `grid` block)")
+	out := fs.String("out", "out/optimize", "output directory")
+	workers := fs.Int("workers", 4, "number of parallel workers")
+	sortBy := fs.String("sort", "sharpe", "sort key: sharpe|net_pnl|win_rate|profit_factor")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *scenario == "" {
+		fs.Usage()
+		return flag.ErrHelp
+	}
+	cfg, err := backtest.LoadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	sc, ok := cfg.Scenarios[*scenario]
+	if !ok {
+		return fmt.Errorf("scenario %q not found", *scenario)
+	}
+	if len(sc.Grid) == 0 {
+		return fmt.Errorf("scenario %q has no grid block", *scenario)
+	}
+
+	combos := expandGrid(sc.Grid, sc.Fixed)
+	fmt.Fprintf(os.Stderr, "optimizing %s: %d combinations, %d workers\n", *scenario, len(combos), *workers)
+
+	type result = optResult
+	jobs := make(chan map[string]interface{})
+	results := make(chan result, len(combos))
+	var wg sync.WaitGroup
+	for i := 0; i < *workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for params := range jobs {
+				r, err := runScenario(ctx, cfg, *scenario, time.Time{}, time.Time{}, params, "", true)
+				results <- result{params: params, res: r, err: err}
+			}
+		}()
+	}
+	go func() {
+		for _, c := range combos {
+			select {
+			case <-ctx.Done():
+				close(jobs)
+				return
+			case jobs <- c:
+			}
+		}
+		close(jobs)
+	}()
+	go func() { wg.Wait(); close(results) }()
+
+	rows := make([]result, 0, len(combos))
+	for r := range results {
+		if r.err != nil {
+			fmt.Fprintf(os.Stderr, "  combo failed: %v\n", r.err)
+			continue
+		}
+		rows = append(rows, r)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return cmpKey(rows[i].res, *sortBy) > cmpKey(rows[j].res, *sortBy)
+	})
+
+	if err := os.MkdirAll(*out, 0o755); err != nil {
+		return err
+	}
+	csvPath := filepath.Join(*out, "grid.csv")
+	if err := writeGridCSV(csvPath, rows, sortedKeys(sc.Grid)); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s (%d rows, sorted by %s)\n", csvPath, len(rows), *sortBy)
+	if len(rows) > 0 {
+		printTopRows(rows, sortedKeys(sc.Grid), 10)
+	}
+	return nil
+}
+
+// expandGrid is the cartesian product over `grid`, merging in `fixed`.
+func expandGrid(grid map[string][]interface{}, fixed map[string]interface{}) []map[string]interface{} {
+	keys := sortedKeys(grid)
+	combos := []map[string]interface{}{copyParams(fixed)}
+	for _, k := range keys {
+		next := make([]map[string]interface{}, 0, len(combos)*len(grid[k]))
+		for _, c := range combos {
+			for _, v := range grid[k] {
+				nc := copyParams(c)
+				nc[k] = v
+				next = append(next, nc)
+			}
+		}
+		combos = next
+	}
+	return combos
+}
+
+func sortedKeys(m map[string][]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func copyParams(in map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func cmpKey(r *backtest.Result, key string) float64 {
+	switch key {
+	case "win_rate":
+		return r.Summary.WinRate
+	case "net_pnl":
+		return r.Summary.NetPnL
+	case "profit_factor":
+		return r.Summary.ProfitFactor
+	case "sharpe":
+		return r.Summary.SharpeAnnualised
+	default:
+		return r.Summary.SharpeAnnualised
+	}
+}
+
+type optResult struct {
+	params map[string]interface{}
+	res    *backtest.Result
+	err    error
+}
+
+func writeGridCSV(path string, rows []optResult, gridKeys []string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	header := append([]string{}, gridKeys...)
+	header = append(header, "trades", "win_rate", "net_pnl", "profit_factor",
+		"max_dd_pct", "sharpe", "sortino", "fees", "slippage")
+	if err := w.Write(header); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		row := make([]string, 0, len(header))
+		for _, k := range gridKeys {
+			row = append(row, fmt.Sprintf("%v", r.params[k]))
+		}
+		s := r.res.Summary
+		row = append(row,
+			strconv.Itoa(s.TotalTrades),
+			fmtFloat(s.WinRate),
+			fmtFloat(s.NetPnL),
+			fmtFloat(s.ProfitFactor),
+			fmtFloat(s.MaxDrawdown*100),
+			fmtFloat(s.SharpeAnnualised),
+			fmtFloat(s.Sortino),
+			fmtFloat(s.TotalFees),
+			fmtFloat(s.TotalSlippage),
+		)
+		if err := w.Write(row); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+func printTopRows(rows []optResult, gridKeys []string, n int) {
+	if n > len(rows) {
+		n = len(rows)
+	}
+	fmt.Println("\nTop", n, "results:")
+	for i := 0; i < n; i++ {
+		s := rows[i].res.Summary
+		fmt.Printf("  #%-2d  trades=%-4d  win=%5.1f%%  net=%+8.1f  PF=%5.2f  Sharpe=%6.2f  ",
+			i+1, s.TotalTrades, s.WinRate, s.NetPnL, s.ProfitFactor, s.SharpeAnnualised)
+		for _, k := range gridKeys {
+			fmt.Printf("%s=%v ", k, rows[i].params[k])
+		}
+		fmt.Println()
+	}
+}
+
+func fmtFloat(v float64) string { return strconv.FormatFloat(v, 'f', 4, 64) }

--- a/pkg/backtest/cli/run.go
+++ b/pkg/backtest/cli/run.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"context"
+	"flag"
+
+	"github.com/bmf-san/gogocoin/pkg/backtest"
+)
+
+// Run implements `backtest run`.
+func Run(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	configPath := fs.String("config", "configs/backtest.yaml", "path to backtest YAML config")
+	scenario := fs.String("scenario", "", "scenario name to run (required)")
+	from := fs.String("from", "", "override data.from (YYYY-MM-DD)")
+	to := fs.String("to", "", "override data.to (YYYY-MM-DD)")
+	out := fs.String("out", "", "output directory for trades.csv / equity.csv / signals.csv")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *scenario == "" {
+		fs.Usage()
+		return flag.ErrHelp
+	}
+	cfg, err := backtest.LoadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	fromT, err := backtest.ParseDate(*from)
+	if err != nil {
+		return err
+	}
+	toT, err := backtest.ParseDate(*to)
+	if err != nil {
+		return err
+	}
+	_, err = runScenario(ctx, cfg, *scenario, fromT, toT, nil, outDirOrEmpty(*out), false)
+	return err
+}

--- a/pkg/backtest/cli/walkforward.go
+++ b/pkg/backtest/cli/walkforward.go
@@ -1,0 +1,194 @@
+package cli
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/bmf-san/gogocoin/pkg/backtest"
+)
+
+// wfWindow holds train + test window results for one walk-forward step.
+type wfWindow struct {
+	TrainFrom, TrainTo time.Time
+	TestFrom, TestTo   time.Time
+	BestParams         map[string]interface{}
+	Train              *backtest.Result
+	Test               *backtest.Result
+}
+
+// WalkForward implements `backtest walkforward`.
+//
+// Splits the configured date range into rolling [train, test] windows.
+// On each train window we run a quick grid search to pick the best params,
+// then evaluate them on the immediately-following test window. The output
+// CSV records test-window stats — these are the only honest metrics.
+func WalkForward(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("walkforward", flag.ContinueOnError)
+	configPath := fs.String("config", "configs/backtest.yaml", "path to backtest YAML config")
+	scenario := fs.String("scenario", "", "scenario name (must define a `grid` block)")
+	trainDays := fs.Int("train-days", 60, "size of training window")
+	testDays := fs.Int("test-days", 14, "size of testing window")
+	step := fs.Int("step", 14, "step size between windows (days)")
+	out := fs.String("out", "out/walkforward", "output directory")
+	sortBy := fs.String("sort", "sharpe", "in-sample selection key (sharpe|net_pnl|win_rate|profit_factor)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *scenario == "" {
+		fs.Usage()
+		return flag.ErrHelp
+	}
+	cfg, err := backtest.LoadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	sc, ok := cfg.Scenarios[*scenario]
+	if !ok {
+		return fmt.Errorf("scenario %q not found", *scenario)
+	}
+	if len(sc.Grid) == 0 {
+		return fmt.Errorf("scenario %q needs a grid block", *scenario)
+	}
+	from, err := backtest.ParseDate(cfg.Data.From)
+	if err != nil || from.IsZero() {
+		return fmt.Errorf("data.from required for walk-forward")
+	}
+	to, err := backtest.ParseDate(cfg.Data.To)
+	if err != nil || to.IsZero() {
+		return fmt.Errorf("data.to required for walk-forward")
+	}
+
+	combos := expandGrid(sc.Grid, sc.Fixed)
+	gridKeys := sortedKeys(sc.Grid)
+
+	type windowResult = wfWindow
+	var windows []windowResult
+
+	cursor := from
+	for {
+		trainTo := cursor.AddDate(0, 0, *trainDays)
+		testTo := trainTo.AddDate(0, 0, *testDays)
+		if testTo.After(to) {
+			break
+		}
+		fmt.Fprintf(os.Stderr, "window: train %s..%s  test %s..%s\n",
+			cursor.Format("2006-01-02"), trainTo.Format("2006-01-02"),
+			trainTo.Format("2006-01-02"), testTo.Format("2006-01-02"))
+
+		// Grid search on training window.
+		var best *backtest.Result
+		var bestParams map[string]interface{}
+		for _, params := range combos {
+			r, err := runScenario(ctx, cfg, *scenario, cursor, trainTo, params, "", true)
+			if err != nil {
+				continue
+			}
+			if best == nil || cmpKey(r, *sortBy) > cmpKey(best, *sortBy) {
+				best = r
+				bestParams = params
+			}
+		}
+		if best == nil {
+			fmt.Fprintln(os.Stderr, "  no successful train run; skipping")
+			cursor = cursor.AddDate(0, 0, *step)
+			continue
+		}
+		// Evaluate best params on test window.
+		test, err := runScenario(ctx, cfg, *scenario, trainTo, testTo, bestParams, "", true)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  test failed: %v\n", err)
+			cursor = cursor.AddDate(0, 0, *step)
+			continue
+		}
+		windows = append(windows, windowResult{
+			TrainFrom: cursor, TrainTo: trainTo,
+			TestFrom: trainTo, TestTo: testTo,
+			BestParams: bestParams,
+			Train:      best, Test: test,
+		})
+		cursor = cursor.AddDate(0, 0, *step)
+	}
+
+	if err := os.MkdirAll(*out, 0o755); err != nil {
+		return err
+	}
+	csvPath := filepath.Join(*out, "windows.csv")
+	if err := writeWalkForwardCSV(csvPath, windows, gridKeys); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s (%d windows)\n", csvPath, len(windows))
+	if len(windows) == 0 {
+		return nil
+	}
+
+	// Aggregate test-window metrics.
+	var totalNet, totalTrades float64
+	var winsSum, lossesSum int
+	for _, w := range windows {
+		totalNet += w.Test.Summary.NetPnL
+		totalTrades += float64(w.Test.Summary.TotalTrades)
+		winsSum += w.Test.Summary.Wins
+		lossesSum += w.Test.Summary.Losses
+	}
+	winRate := 0.0
+	if winsSum+lossesSum > 0 {
+		winRate = float64(winsSum) / float64(winsSum+lossesSum) * 100
+	}
+	fmt.Printf("\n[ Walk-forward aggregate (out-of-sample only) ]\n")
+	fmt.Printf("  windows:    %d\n", len(windows))
+	fmt.Printf("  trades:     %.0f\n", totalTrades)
+	fmt.Printf("  win rate:   %.2f %%\n", winRate)
+	fmt.Printf("  total P&L:  %+.2f JPY\n", totalNet)
+	return nil
+}
+
+func writeWalkForwardCSV(path string, windows []wfWindow, gridKeys []string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	header := []string{"train_from", "train_to", "test_from", "test_to"}
+	for _, k := range gridKeys {
+		header = append(header, "best_"+k)
+	}
+	header = append(header,
+		"train_trades", "train_win_rate", "train_net_pnl", "train_sharpe",
+		"test_trades", "test_win_rate", "test_net_pnl", "test_sharpe")
+	if err := w.Write(header); err != nil {
+		return err
+	}
+	for _, ww := range windows {
+		row := []string{
+			ww.TrainFrom.Format("2006-01-02"),
+			ww.TrainTo.Format("2006-01-02"),
+			ww.TestFrom.Format("2006-01-02"),
+			ww.TestTo.Format("2006-01-02"),
+		}
+		for _, k := range gridKeys {
+			row = append(row, fmt.Sprintf("%v", ww.BestParams[k]))
+		}
+		row = append(row,
+			strconv.Itoa(ww.Train.Summary.TotalTrades),
+			fmtFloat(ww.Train.Summary.WinRate),
+			fmtFloat(ww.Train.Summary.NetPnL),
+			fmtFloat(ww.Train.Summary.SharpeAnnualised),
+			strconv.Itoa(ww.Test.Summary.TotalTrades),
+			fmtFloat(ww.Test.Summary.WinRate),
+			fmtFloat(ww.Test.Summary.NetPnL),
+			fmtFloat(ww.Test.Summary.SharpeAnnualised),
+		)
+		if err := w.Write(row); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}

--- a/pkg/backtest/config.go
+++ b/pkg/backtest/config.go
@@ -1,0 +1,131 @@
+package backtest
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the schema of configs/backtest.yaml.
+type Config struct {
+	Data      DataConfig                `yaml:"data"`
+	Simulator SimulatorYAML             `yaml:"simulator"`
+	Scenarios map[string]ScenarioConfig `yaml:"scenarios"`
+}
+
+// DataConfig points to the historical data.
+type DataConfig struct {
+	Source string `yaml:"source"` // "sqlite" | "csv"
+	Path   string `yaml:"path"`
+	Symbol string `yaml:"symbol"`
+	From   string `yaml:"from"` // YYYY-MM-DD
+	To     string `yaml:"to"`
+	// BarPeriod aggregates the raw source bars into larger time-based bars
+	// before feeding them to the strategy. Accepts Go duration strings
+	// (e.g. "5m", "1h", "4h"). Empty/unset = pass through raw bars.
+	BarPeriod string `yaml:"bar_period"`
+}
+
+// SimulatorYAML is the YAML mirror of SimulatorConfig.
+type SimulatorYAML struct {
+	InitialBalance float64 `yaml:"initial_balance"`
+	FeeRate        float64 `yaml:"fee_rate"`
+	SlippageBps    float64 `yaml:"slippage_bps"`
+	SameBarRule    string  `yaml:"same_bar_rule"`
+	MinVolumeRatio float64 `yaml:"min_volume_ratio"`
+}
+
+// ScenarioConfig describes a single backtest case.
+type ScenarioConfig struct {
+	Strategy     string                   `yaml:"strategy"`
+	Params       map[string]interface{}   `yaml:"params"`
+	Grid         map[string][]interface{} `yaml:"grid"`
+	Fixed        map[string]interface{}   `yaml:"fixed"`
+	DataOverride *DataOverride            `yaml:"data_override,omitempty"`
+	// HistoryLimit overrides the engine's default sliding history size for
+	// this scenario. Use this when a strategy needs more than ~1000 bars
+	// of look-back (e.g. swing strategies with 200-bar EMAs on 1h data).
+	HistoryLimit int `yaml:"history_limit"`
+}
+
+// DataOverride lets a scenario override fields on the top-level data block.
+// Empty fields fall through to the parent DataConfig.
+type DataOverride struct {
+	Source    string `yaml:"source"`
+	Path      string `yaml:"path"`
+	Symbol    string `yaml:"symbol"`
+	From      string `yaml:"from"`
+	To        string `yaml:"to"`
+	BarPeriod string `yaml:"bar_period"`
+}
+
+// Apply returns a DataConfig with override fields merged on top of base.
+func (o *DataOverride) Apply(base DataConfig) DataConfig {
+	if o == nil {
+		return base
+	}
+	out := base
+	if o.Source != "" {
+		out.Source = o.Source
+	}
+	if o.Path != "" {
+		out.Path = o.Path
+	}
+	if o.Symbol != "" {
+		out.Symbol = o.Symbol
+	}
+	if o.From != "" {
+		out.From = o.From
+	}
+	if o.To != "" {
+		out.To = o.To
+	}
+	if o.BarPeriod != "" {
+		out.BarPeriod = o.BarPeriod
+	}
+	return out
+}
+
+// LoadConfig reads + parses a YAML config file.
+func LoadConfig(path string) (*Config, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %q: %w", path, err)
+	}
+	var c Config
+	if err := yaml.Unmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("parse %q: %w", path, err)
+	}
+	return &c, nil
+}
+
+// ParseDate parses YYYY-MM-DD; returns zero time when s is empty.
+func ParseDate(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse("2006-01-02", s)
+}
+
+// ToSimulatorConfig converts the YAML form to runtime form.
+func (s SimulatorYAML) ToSimulatorConfig() SimulatorConfig {
+	cfg := DefaultSimulatorConfig()
+	if s.InitialBalance > 0 {
+		cfg.InitialBalance = s.InitialBalance
+	}
+	if s.FeeRate > 0 {
+		cfg.FeeRate = s.FeeRate
+	}
+	if s.SlippageBps > 0 {
+		cfg.SlippageBps = s.SlippageBps
+	}
+	if s.SameBarRule != "" {
+		cfg.SameBarRule = SameBarRule(s.SameBarRule)
+	}
+	if s.MinVolumeRatio > 0 {
+		cfg.MinVolumeRatio = s.MinVolumeRatio
+	}
+	return cfg
+}

--- a/pkg/backtest/datasource.go
+++ b/pkg/backtest/datasource.go
@@ -1,0 +1,18 @@
+package backtest
+
+import (
+	"context"
+	"io"
+)
+
+// Datasource yields Bars in strict chronological order. Implementations must
+// return io.EOF (and only io.EOF) when no more data is available.
+type Datasource interface {
+	// Next returns the next Bar. Returns (Bar{}, io.EOF) when exhausted.
+	Next(ctx context.Context) (Bar, error)
+	// Close releases any underlying resources. Idempotent.
+	Close() error
+}
+
+// IsEOF reports whether err signals end of data. Helper for callers.
+func IsEOF(err error) bool { return err == io.EOF }

--- a/pkg/backtest/datasource_csv.go
+++ b/pkg/backtest/datasource_csv.go
@@ -1,0 +1,162 @@
+package backtest
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+)
+
+// CSVDatasource reads Bars from a CSV file with the header:
+//
+//	timestamp,symbol,open,high,low,close,volume
+//
+// Records must be sorted by timestamp ASC. timestamp is parsed using the
+// same set of layouts as parseDBTimestamp.
+type CSVDatasource struct {
+	opts   CSVDatasourceOptions
+	f      *os.File
+	r      *csv.Reader
+	closed bool
+}
+
+// CSVDatasourceOptions configures the CSV reader.
+type CSVDatasourceOptions struct {
+	Path   string
+	Symbol string    // when non-empty, rows with a different symbol are skipped
+	From   time.Time // inclusive
+	To     time.Time // inclusive
+}
+
+// NewCSVDatasource opens path and reads/validates the header.
+func NewCSVDatasource(opts CSVDatasourceOptions) (*CSVDatasource, error) {
+	if opts.Path == "" {
+		return nil, fmt.Errorf("csv datasource: path is required")
+	}
+	f, err := os.Open(opts.Path)
+	if err != nil {
+		return nil, fmt.Errorf("csv open %q: %w", opts.Path, err)
+	}
+	ds := &CSVDatasource{opts: opts, f: f}
+	if err := ds.initReader(); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return ds, nil
+}
+
+func (c *CSVDatasource) initReader() error {
+	c.r = csv.NewReader(c.f)
+	c.r.FieldsPerRecord = 7
+	c.r.TrimLeadingSpace = true
+	header, err := c.r.Read()
+	if err != nil {
+		return fmt.Errorf("csv header: %w", err)
+	}
+	expected := []string{"timestamp", "symbol", "open", "high", "low", "close", "volume"}
+	if len(header) != len(expected) {
+		return fmt.Errorf("csv header: expected %v got %v", expected, header)
+	}
+	for i, want := range expected {
+		if header[i] != want {
+			return fmt.Errorf("csv header[%d]: expected %q got %q", i, want, header[i])
+		}
+	}
+	return nil
+}
+
+// Reopen rewinds the underlying file to the first data row.
+func (c *CSVDatasource) Reopen() error {
+	if _, err := c.f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	c.closed = false
+	return c.initReader()
+}
+
+// Next implements Datasource.
+func (c *CSVDatasource) Next(ctx context.Context) (Bar, error) {
+	if c.closed {
+		return Bar{}, io.EOF
+	}
+	if err := ctx.Err(); err != nil {
+		return Bar{}, err
+	}
+	for {
+		rec, err := c.r.Read()
+		if err == io.EOF {
+			return Bar{}, io.EOF
+		}
+		if err != nil {
+			return Bar{}, fmt.Errorf("csv read: %w", err)
+		}
+		bar, err := parseCSVRecord(rec)
+		if err != nil {
+			return Bar{}, err
+		}
+		if c.opts.Symbol != "" && bar.Symbol != c.opts.Symbol {
+			continue
+		}
+		if !c.opts.From.IsZero() && bar.Timestamp.Before(c.opts.From) {
+			continue
+		}
+		if !c.opts.To.IsZero() && bar.Timestamp.After(c.opts.To) {
+			return Bar{}, io.EOF
+		}
+		return bar, nil
+	}
+}
+
+// Close implements Datasource.
+func (c *CSVDatasource) Close() error {
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	if c.f != nil {
+		return c.f.Close()
+	}
+	return nil
+}
+
+func parseCSVRecord(rec []string) (Bar, error) {
+	if len(rec) != 7 {
+		return Bar{}, fmt.Errorf("csv record: expected 7 fields got %d", len(rec))
+	}
+	t, err := parseDBTimestamp(rec[0])
+	if err != nil {
+		return Bar{}, fmt.Errorf("csv timestamp %q: %w", rec[0], err)
+	}
+	o, err := strconv.ParseFloat(rec[2], 64)
+	if err != nil {
+		return Bar{}, fmt.Errorf("csv open: %w", err)
+	}
+	h, err := strconv.ParseFloat(rec[3], 64)
+	if err != nil {
+		return Bar{}, fmt.Errorf("csv high: %w", err)
+	}
+	l, err := strconv.ParseFloat(rec[4], 64)
+	if err != nil {
+		return Bar{}, fmt.Errorf("csv low: %w", err)
+	}
+	cl, err := strconv.ParseFloat(rec[5], 64)
+	if err != nil {
+		return Bar{}, fmt.Errorf("csv close: %w", err)
+	}
+	v, err := strconv.ParseFloat(rec[6], 64)
+	if err != nil {
+		return Bar{}, fmt.Errorf("csv volume: %w", err)
+	}
+	return Bar{
+		Symbol:    rec[1],
+		Timestamp: t,
+		Open:      o,
+		High:      h,
+		Low:       l,
+		Close:     cl,
+		Volume:    v,
+	}, nil
+}

--- a/pkg/backtest/datasource_resample.go
+++ b/pkg/backtest/datasource_resample.go
@@ -1,0 +1,170 @@
+package backtest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+)
+
+// ResamplingDatasource wraps another Datasource and aggregates its bars
+// into larger time-based bars (e.g. 20s ticks → 1h bars).
+//
+// Period boundaries are aligned to UTC (e.g. a 1h period emits bars at
+// 00:00, 01:00, ... in UTC). The output bar timestamp is the START of the
+// period (left-labeled). OHLCV are aggregated with the conventional rules:
+//
+//	Open   = Open of the first input bar in the window
+//	High   = max High over the window
+//	Low    = min Low over the window
+//	Close  = Close of the last input bar in the window
+//	Volume = sum of Volume over the window
+//
+// Trailing partial windows (i.e. the last bucket when EOF arrives) are
+// emitted as a final bar.
+type ResamplingDatasource struct {
+	inner  Datasource
+	period time.Duration
+
+	// current bucket state
+	have    bool
+	bucket  time.Time // start (UTC) of the current bucket
+	cur     Bar
+	pending *Bar // bar held back because it belongs to the next bucket
+
+	closed bool
+	done   bool
+}
+
+// NewResamplingDatasource returns a Datasource that aggregates inner's bars
+// into period-sized buckets. period must be > 0.
+func NewResamplingDatasource(inner Datasource, period time.Duration) (*ResamplingDatasource, error) {
+	if inner == nil {
+		return nil, fmt.Errorf("resampling datasource: inner is required")
+	}
+	if period <= 0 {
+		return nil, fmt.Errorf("resampling datasource: period must be > 0")
+	}
+	return &ResamplingDatasource{inner: inner, period: period}, nil
+}
+
+// bucketStart returns the UTC-aligned start of the bucket containing t.
+func bucketStart(t time.Time, period time.Duration) time.Time {
+	u := t.UTC()
+	ns := u.UnixNano()
+	bucketNs := period.Nanoseconds()
+	startNs := ns - (ns % bucketNs)
+	if ns < 0 && ns%bucketNs != 0 {
+		startNs -= bucketNs
+	}
+	return time.Unix(0, startNs).UTC()
+}
+
+// Next returns the next aggregated Bar, or io.EOF when exhausted.
+func (r *ResamplingDatasource) Next(ctx context.Context) (Bar, error) {
+	if r.closed {
+		return Bar{}, io.EOF
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return Bar{}, err
+		}
+		// Pull next input bar (either pending from the prior call, or new).
+		var (
+			b   Bar
+			err error
+		)
+		if r.pending != nil {
+			b = *r.pending
+			r.pending = nil
+		} else if r.done {
+			// EOF already seen; flush whatever bucket we have.
+			if r.have {
+				out := r.cur
+				r.have = false
+				return out, nil
+			}
+			return Bar{}, io.EOF
+		} else {
+			b, err = r.inner.Next(ctx)
+			if err != nil {
+				if err == io.EOF {
+					r.done = true
+					if r.have {
+						out := r.cur
+						r.have = false
+						return out, nil
+					}
+					return Bar{}, io.EOF
+				}
+				return Bar{}, err
+			}
+		}
+
+		bb := bucketStart(b.Timestamp, r.period)
+
+		if !r.have {
+			// Start a new bucket from this bar.
+			r.bucket = bb
+			r.cur = Bar{
+				Symbol:    b.Symbol,
+				Timestamp: bb,
+				Open:      b.Open,
+				High:      b.High,
+				Low:       b.Low,
+				Close:     b.Close,
+				Volume:    b.Volume,
+			}
+			r.have = true
+			continue
+		}
+
+		if bb.Equal(r.bucket) {
+			// Same bucket → fold in.
+			if b.High > r.cur.High {
+				r.cur.High = b.High
+			}
+			if b.Low < r.cur.Low {
+				r.cur.Low = b.Low
+			}
+			r.cur.Close = b.Close
+			r.cur.Volume += b.Volume
+			continue
+		}
+
+		// New bucket starts → emit current, stash this bar as pending.
+		out := r.cur
+		r.have = false
+		bCopy := b
+		r.pending = &bCopy
+		return out, nil
+	}
+}
+
+// Close closes the inner datasource. Idempotent.
+func (r *ResamplingDatasource) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	if r.inner != nil {
+		return r.inner.Close()
+	}
+	return nil
+}
+
+// ParseBarPeriod parses strings like "20s", "1m", "5m", "1h", "4h".
+// An empty string returns 0 with no error (caller decides default).
+func ParseBarPeriod(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid bar_period %q: %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("bar_period must be > 0, got %s", s)
+	}
+	return d, nil
+}

--- a/pkg/backtest/datasource_resample_test.go
+++ b/pkg/backtest/datasource_resample_test.go
@@ -1,0 +1,129 @@
+package backtest
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+)
+
+// staticDS yields a pre-built slice of bars.
+type staticDS struct {
+	bars []Bar
+	i    int
+}
+
+func (s *staticDS) Next(_ context.Context) (Bar, error) {
+	if s.i >= len(s.bars) {
+		return Bar{}, io.EOF
+	}
+	b := s.bars[s.i]
+	s.i++
+	return b, nil
+}
+func (s *staticDS) Close() error { return nil }
+
+func mkBar(tsRFC3339 string, o, h, l, c, v float64) Bar {
+	t, err := time.Parse(time.RFC3339, tsRFC3339)
+	if err != nil {
+		panic(err)
+	}
+	return Bar{
+		Symbol: "XRP_JPY", Timestamp: t, Open: o, High: h, Low: l, Close: c, Volume: v,
+	}
+}
+
+func TestResampling_1h(t *testing.T) {
+	// Three 20-min bars in 00:00-00:60 (UTC), then one in 01:00-02:00.
+	bars := []Bar{
+		mkBar("2026-01-01T00:00:00Z", 100, 105, 99, 102, 1.0),
+		mkBar("2026-01-01T00:20:00Z", 102, 110, 101, 108, 2.0),
+		mkBar("2026-01-01T00:40:00Z", 108, 109, 95, 96, 3.0),
+		mkBar("2026-01-01T01:10:00Z", 96, 97, 90, 91, 5.0),
+	}
+	ds, err := NewResamplingDatasource(&staticDS{bars: bars}, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+
+	ctx := context.Background()
+	got := []Bar{}
+	for {
+		b, err := ds.Next(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, b)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 aggregated bars, got %d: %+v", len(got), got)
+	}
+	// Bucket 0: 00:00 — Open 100 (first), High 110, Low 95, Close 96, Volume 6.
+	if g := got[0]; g.Open != 100 || g.High != 110 || g.Low != 95 || g.Close != 96 || g.Volume != 6.0 {
+		t.Errorf("bucket0 wrong: %+v", g)
+	}
+	if !got[0].Timestamp.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("bucket0 ts: %v", got[0].Timestamp)
+	}
+	// Bucket 1: 01:00 — single bar passes through.
+	if g := got[1]; g.Open != 96 || g.High != 97 || g.Low != 90 || g.Close != 91 || g.Volume != 5.0 {
+		t.Errorf("bucket1 wrong: %+v", g)
+	}
+	if !got[1].Timestamp.Equal(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)) {
+		t.Errorf("bucket1 ts: %v", got[1].Timestamp)
+	}
+}
+
+func TestResampling_PassThrough_WhenZeroPeriod(t *testing.T) {
+	_, err := NewResamplingDatasource(&staticDS{}, 0)
+	if err == nil {
+		t.Fatal("expected error for zero period")
+	}
+}
+
+func TestResampling_EmptySource(t *testing.T) {
+	ds, err := NewResamplingDatasource(&staticDS{}, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ds.Close()
+	_, err = ds.Next(context.Background())
+	if err != io.EOF {
+		t.Fatalf("want EOF, got %v", err)
+	}
+}
+
+func TestParseBarPeriod(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+		err  bool
+	}{
+		{"", 0, false},
+		{"1h", time.Hour, false},
+		{"4h", 4 * time.Hour, false},
+		{"5m", 5 * time.Minute, false},
+		{"20s", 20 * time.Second, false},
+		{"-1h", 0, true},
+		{"abc", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseBarPeriod(c.in)
+		if c.err {
+			if err == nil {
+				t.Errorf("%q: expected error", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%q: %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("%q: got %v want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/pkg/backtest/datasource_sqlite.go
+++ b/pkg/backtest/datasource_sqlite.go
@@ -1,0 +1,156 @@
+package backtest
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3" // sqlite driver
+)
+
+// SQLiteDatasource reads Bars from the gogocoin `market_data` table.
+//
+// Schema (see gogocoin internal/infra/persistence/schema/001_initial.sql):
+//
+//	market_data(symbol TEXT, timestamp DATETIME, open REAL, high REAL,
+//	            low REAL, close REAL, volume REAL, ...)
+//
+// SQLite stores timestamps as RFC3339-ish strings with a numeric offset
+// (e.g. `2026-04-04 00:00:10.743+09:00`). We try a small list of layouts
+// to be tolerant of historical variation.
+type SQLiteDatasource struct {
+	db     *sql.DB
+	rows   *sql.Rows
+	closed bool
+}
+
+// SQLiteDatasourceOptions configures the query bounds.
+type SQLiteDatasourceOptions struct {
+	Path   string
+	Symbol string
+	From   time.Time // inclusive; zero = no lower bound
+	To     time.Time // inclusive; zero = no upper bound
+}
+
+// NewSQLiteDatasource opens path and prepares an iterator over bars matching
+// opts. Caller must Close() the returned datasource.
+func NewSQLiteDatasource(opts SQLiteDatasourceOptions) (*SQLiteDatasource, error) {
+	if opts.Path == "" {
+		return nil, fmt.Errorf("sqlite datasource: path is required")
+	}
+	if opts.Symbol == "" {
+		return nil, fmt.Errorf("sqlite datasource: symbol is required")
+	}
+	// Open read-only to avoid contention with a running gogocoin process.
+	// `immutable=1` skips WAL journal setup which would otherwise require
+	// write access to the DB file/directory.
+	dsn := fmt.Sprintf("file:%s?mode=ro&immutable=1", opts.Path)
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite open %q: %w", opts.Path, err)
+	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite ping %q: %w", opts.Path, err)
+	}
+
+	q := `SELECT symbol, timestamp, open, high, low, close, volume
+	      FROM market_data
+	      WHERE symbol = ?`
+	args := []interface{}{opts.Symbol}
+	if !opts.From.IsZero() {
+		q += " AND timestamp >= ?"
+		args = append(args, opts.From.Format(time.RFC3339))
+	}
+	if !opts.To.IsZero() {
+		q += " AND timestamp <= ?"
+		args = append(args, opts.To.Format(time.RFC3339))
+	}
+	q += " ORDER BY timestamp ASC"
+
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite query: %w", err)
+	}
+	return &SQLiteDatasource{db: db, rows: rows}, nil
+}
+
+// Next implements Datasource.
+func (s *SQLiteDatasource) Next(ctx context.Context) (Bar, error) {
+	if s.closed {
+		return Bar{}, io.EOF
+	}
+	if err := ctx.Err(); err != nil {
+		return Bar{}, err
+	}
+	if !s.rows.Next() {
+		if err := s.rows.Err(); err != nil {
+			return Bar{}, err
+		}
+		return Bar{}, io.EOF
+	}
+	var (
+		symbol        string
+		tsStr         string
+		o, h, l, c, v float64
+	)
+	if err := s.rows.Scan(&symbol, &tsStr, &o, &h, &l, &c, &v); err != nil {
+		return Bar{}, fmt.Errorf("sqlite scan: %w", err)
+	}
+	t, err := parseDBTimestamp(tsStr)
+	if err != nil {
+		return Bar{}, fmt.Errorf("sqlite parse timestamp %q: %w", tsStr, err)
+	}
+	return Bar{
+		Symbol:    symbol,
+		Timestamp: t,
+		Open:      o,
+		High:      h,
+		Low:       l,
+		Close:     c,
+		Volume:    v,
+	}, nil
+}
+
+// Close implements Datasource.
+func (s *SQLiteDatasource) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	var firstErr error
+	if s.rows != nil {
+		if err := s.rows.Close(); err != nil {
+			firstErr = err
+		}
+	}
+	if s.db != nil {
+		if err := s.db.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// parseDBTimestamp parses the timestamp formats observed in gogocoin DBs.
+// Order matters: try the most specific first.
+func parseDBTimestamp(s string) (time.Time, error) {
+	layouts := []string{
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999-07:00",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02T15:04:05.999999999-07:00",
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05",
+	}
+	for _, l := range layouts {
+		if t, err := time.Parse(l, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognized timestamp layout")
+}

--- a/pkg/backtest/engine.go
+++ b/pkg/backtest/engine.go
@@ -1,0 +1,256 @@
+package backtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	pkgstrategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+// HistoryLimit is the maximum number of MarketData points retained when
+// invoking Strategy.GenerateSignal. Mirrors live engine default.
+const HistoryLimit = 1000
+
+// EngineConfig wires the engine.
+type EngineConfig struct {
+	Strategy        pkgstrategy.Strategy
+	Datasource      Datasource
+	Simulator       SimulatorConfig
+	HistoryLimit    int // 0 → HistoryLimit
+	WarmupBars      int // initial bars excluded from signal evaluation
+	EquityEveryNBar int // sample equity every N bars (default: 1)
+	OnProgress      func(barCount int, last Bar)
+}
+
+// Result is the output of a backtest run.
+type Result struct {
+	StrategyName string
+	Symbol       string
+	StartTime    time.Time
+	EndTime      time.Time
+	Bars         int
+	Trades       []Trade
+	Equity       []EquityPoint
+	SignalCounts []SignalCount
+	InitialCash  float64
+	FinalCash    float64
+	FinalEquity  float64
+	Summary      Summary
+}
+
+// Engine drives the backtest.
+type Engine struct {
+	cfg EngineConfig
+}
+
+// NewEngine constructs an Engine; arguments are validated lazily in Run.
+func NewEngine(cfg EngineConfig) *Engine {
+	return &Engine{cfg: cfg}
+}
+
+// Run executes the backtest until the datasource is exhausted.
+func (e *Engine) Run(ctx context.Context) (*Result, error) {
+	if e.cfg.Strategy == nil {
+		return nil, errors.New("backtest: Strategy is required")
+	}
+	if e.cfg.Datasource == nil {
+		return nil, errors.New("backtest: Datasource is required")
+	}
+	if e.cfg.Simulator.InitialBalance <= 0 {
+		return nil, errors.New("backtest: Simulator.InitialBalance must be > 0")
+	}
+	histLimit := e.cfg.HistoryLimit
+	if histLimit <= 0 {
+		histLimit = HistoryLimit
+	}
+	equityEvery := e.cfg.EquityEveryNBar
+	if equityEvery <= 0 {
+		equityEvery = 1
+	}
+
+	// Lifecycle: start the strategy.
+	if err := e.cfg.Strategy.Start(ctx); err != nil {
+		return nil, fmt.Errorf("strategy.Start: %w", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = e.cfg.Strategy.Stop(stopCtx)
+	}()
+
+	portfolio := NewPortfolio(e.cfg.Simulator.InitialBalance)
+	sim := NewSimulator(e.cfg.Simulator, portfolio)
+
+	history := make([]pkgstrategy.MarketData, 0, histLimit)
+	signalCounts := make(map[string]int)
+
+	var (
+		barCount  int
+		startTime time.Time
+		endTime   time.Time
+		symbol    string
+		curr, nxt Bar
+		hasCurr   bool
+	)
+
+	// Two-bar lookahead window: signals from bar N execute on bar N+1's open.
+	// We always keep one buffered bar so that when we get the new bar, the
+	// previously-buffered one becomes "curr" and the new one becomes "nxt".
+	advance := func(b Bar) {
+		if hasCurr {
+			// Promote previous nxt → curr. (curr is what we evaluate.)
+			curr = nxt
+		}
+		nxt = b
+		hasCurr = true
+	}
+
+	for {
+		bar, err := e.cfg.Datasource.Next(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("datasource: %w", err)
+		}
+		if barCount == 0 {
+			startTime = bar.Timestamp
+			symbol = bar.Symbol
+		}
+		endTime = bar.Timestamp
+		barCount++
+
+		// First bar: just buffer.
+		if !hasCurr {
+			advance(bar)
+			continue
+		}
+		// From here on we always have (curr, nxt). Process curr, then
+		// shift in the new bar.
+		processed := curr
+		nextBar := bar
+
+		// 1. Mark-to-market at curr's close.
+		if barCount%equityEvery == 0 {
+			portfolio.MarkToMarket(processed.Timestamp, processed.Close)
+		}
+
+		// 2. TP/SL on the open position using curr's high/low.
+		// Position may be closed via TP/SL; signal evaluation still runs
+		// so a re-entry can be considered on this bar.
+		_, _ = sim.HandleExit(processed)
+
+		// 3. Append to history & evaluate strategy if past warmup.
+		md := barToMarketData(processed)
+		history = append(history, md)
+		if len(history) > histLimit {
+			history = history[len(history)-histLimit:]
+		}
+
+		if barCount > e.cfg.WarmupBars {
+			signal, err := e.cfg.Strategy.GenerateSignal(ctx, &md, history)
+			if err != nil {
+				return nil, fmt.Errorf("GenerateSignal at %s: %w", processed.Timestamp.Format(time.RFC3339), err)
+			}
+			if signal != nil {
+				key := signalKey(signal)
+				signalCounts[key]++
+				_, _ = sim.HandleSignal(processed, nextBar, signal, true, e.cfg.Strategy)
+			}
+		}
+
+		if e.cfg.OnProgress != nil {
+			e.cfg.OnProgress(barCount, processed)
+		}
+		advance(bar)
+	}
+
+	// Drain the final buffered bar (no nxt → cannot enter, only mark / TP / SL).
+	if hasCurr {
+		// Process the last bar without a "next bar" — only mark-to-market and
+		// TP/SL via the bar's own range.
+		final := nxt
+		_, _ = sim.HandleExit(final)
+		portfolio.MarkToMarket(final.Timestamp, final.Close)
+		// Force-close any remaining open position at last close.
+		if portfolio.Position() != nil {
+			_, _ = sim.ForceClose(final.Timestamp, final.Close)
+			portfolio.MarkToMarket(final.Timestamp, final.Close)
+		}
+	}
+
+	// Final equity sample.
+	finalPrice := 0.0
+	if len(history) > 0 {
+		finalPrice = history[len(history)-1].Price
+	}
+	finalEq := portfolio.Cash()
+	if portfolio.Position() != nil && finalPrice > 0 {
+		finalEq += portfolio.Position().MarkValue(finalPrice)
+	}
+
+	res := &Result{
+		StrategyName: e.cfg.Strategy.Name(),
+		Symbol:       symbol,
+		StartTime:    startTime,
+		EndTime:      endTime,
+		Bars:         barCount,
+		Trades:       portfolio.Trades(),
+		Equity:       portfolio.Equity(),
+		SignalCounts: flattenSignalCounts(signalCounts),
+		InitialCash:  e.cfg.Simulator.InitialBalance,
+		FinalCash:    portfolio.Cash(),
+		FinalEquity:  finalEq,
+	}
+	res.Summary = ComputeSummary(res)
+	return res, nil
+}
+
+func barToMarketData(b Bar) pkgstrategy.MarketData {
+	return pkgstrategy.MarketData{
+		Symbol:    b.Symbol,
+		Timestamp: b.Timestamp,
+		Price:     b.Close,
+		Volume:    b.Volume,
+		Open:      b.Open,
+		High:      b.High,
+		Low:       b.Low,
+		Close:     b.Close,
+	}
+}
+
+func signalKey(s *pkgstrategy.Signal) string {
+	reason := ""
+	if s.Metadata != nil {
+		if r, ok := s.Metadata["reason"].(string); ok {
+			reason = r
+		}
+	}
+	return string(s.Action) + "|" + reason
+}
+
+func flattenSignalCounts(m map[string]int) []SignalCount {
+	out := make([]SignalCount, 0, len(m))
+	for k, v := range m {
+		// split on first '|'
+		idx := -1
+		for i := 0; i < len(k); i++ {
+			if k[i] == '|' {
+				idx = i
+				break
+			}
+		}
+		var act, reason string
+		if idx < 0 {
+			act = k
+		} else {
+			act = k[:idx]
+			reason = k[idx+1:]
+		}
+		out = append(out, SignalCount{Action: act, Reason: reason, Count: v})
+	}
+	return out
+}

--- a/pkg/backtest/engine_test.go
+++ b/pkg/backtest/engine_test.go
@@ -1,0 +1,331 @@
+package backtest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	pkgstrategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+// fakeStrategy is a deterministic strategy used by engine tests.
+// It emits the next pre-programmed signal on each GenerateSignal call.
+type fakeStrategy struct {
+	*pkgstrategy.BaseStrategy
+	signals  []pkgstrategy.SignalAction
+	idx      int
+	tpPct    float64
+	slPct    float64
+	notional float64
+	recorded int
+}
+
+func newFakeStrategy(actions []pkgstrategy.SignalAction, tpPct, slPct, notional float64) *fakeStrategy {
+	return &fakeStrategy{
+		BaseStrategy: pkgstrategy.NewBaseStrategy("fake", "test fake", "0"),
+		signals:      actions,
+		tpPct:        tpPct,
+		slPct:        slPct,
+		notional:     notional,
+	}
+}
+
+func (f *fakeStrategy) GenerateSignal(_ context.Context, d *pkgstrategy.MarketData, _ []pkgstrategy.MarketData) (*pkgstrategy.Signal, error) {
+	if f.idx >= len(f.signals) {
+		return f.CreateSignal(d.Symbol, pkgstrategy.SignalHold, 0, d.Price, 0, nil), nil
+	}
+	a := f.signals[f.idx]
+	f.idx++
+	return f.CreateSignal(d.Symbol, a, 1, d.Price, 0, map[string]interface{}{"reason": "fake"}), nil
+}
+
+func (f *fakeStrategy) Analyze(_ []pkgstrategy.MarketData) (*pkgstrategy.Signal, error) {
+	return nil, nil
+}
+
+func (f *fakeStrategy) Initialize(_ map[string]interface{}) error   { return nil }
+func (f *fakeStrategy) UpdateConfig(_ map[string]interface{}) error { return nil }
+func (f *fakeStrategy) GetTakeProfitPrice(entry float64) float64 {
+	if f.tpPct == 0 {
+		return 0
+	}
+	return entry * (1 + f.tpPct/100)
+}
+func (f *fakeStrategy) GetStopLossPrice(entry float64) float64 {
+	if f.slPct == 0 {
+		return 0
+	}
+	return entry * (1 - f.slPct/100)
+}
+func (f *fakeStrategy) GetBaseNotional(_ string) float64 { return f.notional }
+func (f *fakeStrategy) GetAutoScaleConfig() pkgstrategy.AutoScaleConfig {
+	return pkgstrategy.AutoScaleConfig{}
+}
+func (f *fakeStrategy) RecordTrade() { f.recorded++ }
+
+// sliceDS is a Datasource backed by an in-memory slice.
+type sliceDS struct {
+	bars []Bar
+	i    int
+}
+
+func (s *sliceDS) Next(ctx context.Context) (Bar, error) {
+	if err := ctx.Err(); err != nil {
+		return Bar{}, err
+	}
+	if s.i >= len(s.bars) {
+		return Bar{}, io.EOF
+	}
+	b := s.bars[s.i]
+	s.i++
+	return b, nil
+}
+func (s *sliceDS) Close() error { return nil }
+
+func mkBars(prices [][4]float64, start time.Time) []Bar {
+	bars := make([]Bar, len(prices))
+	for i, p := range prices {
+		bars[i] = Bar{
+			Symbol:    "XRP_JPY",
+			Timestamp: start.Add(time.Duration(i) * time.Minute),
+			Open:      p[0],
+			High:      p[1],
+			Low:       p[2],
+			Close:     p[3],
+			Volume:    1_000_000,
+		}
+	}
+	return bars
+}
+
+func TestSimulator_TPHit(t *testing.T) {
+	// Bars: bar0 buy signal, bar1 entry @ open=100, bar2 high=101 hits TP.
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bars := mkBars([][4]float64{
+		{100, 100, 100, 100}, // bar0 — signal: BUY
+		{100, 100, 100, 100}, // bar1 — fill entry at open=100 (post-slip 100*1.0005=100.05)
+		{100, 102, 100, 101}, // bar2 — TP hit (entry*1.005=100.55, high=102 ≥ TP)
+	}, start)
+	strat := newFakeStrategy([]pkgstrategy.SignalAction{pkgstrategy.SignalBuy}, 0.5, 1.0, 1000)
+	cfg := EngineConfig{
+		Strategy:   strat,
+		Datasource: &sliceDS{bars: bars},
+		Simulator: SimulatorConfig{
+			InitialBalance: 100_000,
+			FeeRate:        0.0015,
+			SlippageBps:    5,
+			SameBarRule:    SameBarSLPriority,
+		},
+	}
+	res, err := NewEngine(cfg).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(res.Trades))
+	}
+	tr := res.Trades[0]
+	if tr.Reason != ExitReasonTP {
+		t.Errorf("expected TP exit, got %s", tr.Reason)
+	}
+	if tr.NetPnL <= 0 {
+		t.Errorf("TP exit should be a winner, got NetPnL=%.4f", tr.NetPnL)
+	}
+}
+
+func TestSimulator_SLHit(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bars := mkBars([][4]float64{
+		{100, 100, 100, 100},
+		{100, 100, 100, 100},
+		{100, 100, 98, 99}, // SL=99.05 hit by low=98 → SL exit
+	}, start)
+	strat := newFakeStrategy([]pkgstrategy.SignalAction{pkgstrategy.SignalBuy}, 5.0, 1.0, 1000)
+	cfg := EngineConfig{
+		Strategy:   strat,
+		Datasource: &sliceDS{bars: bars},
+		Simulator: SimulatorConfig{
+			InitialBalance: 100_000,
+			FeeRate:        0.0015,
+			SlippageBps:    5,
+		},
+	}
+	res, err := NewEngine(cfg).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(res.Trades))
+	}
+	if res.Trades[0].Reason != ExitReasonSL {
+		t.Errorf("expected SL exit, got %s", res.Trades[0].Reason)
+	}
+	if res.Trades[0].NetPnL >= 0 {
+		t.Errorf("SL exit should be a loser, got %.4f", res.Trades[0].NetPnL)
+	}
+}
+
+func TestSimulator_SameBarSLPriority(t *testing.T) {
+	// Bar where both TP and SL are reachable; SL must win under default rule.
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bars := mkBars([][4]float64{
+		{100, 100, 100, 100},
+		{100, 100, 100, 100},
+		{100, 102, 98, 100}, // both TP=100.55 and SL=99.05 reachable
+	}, start)
+	strat := newFakeStrategy([]pkgstrategy.SignalAction{pkgstrategy.SignalBuy}, 0.5, 1.0, 1000)
+	cfg := EngineConfig{
+		Strategy:   strat,
+		Datasource: &sliceDS{bars: bars},
+		Simulator: SimulatorConfig{
+			InitialBalance: 100_000,
+			FeeRate:        0.0015,
+			SlippageBps:    5,
+			SameBarRule:    SameBarSLPriority,
+		},
+	}
+	res, err := NewEngine(cfg).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(res.Trades))
+	}
+	if res.Trades[0].Reason != ExitReasonSL {
+		t.Errorf("expected SL under sl_priority, got %s", res.Trades[0].Reason)
+	}
+}
+
+func TestSimulator_SignalExit(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bars := mkBars([][4]float64{
+		{100, 100, 100, 100},
+		{100, 100, 100, 100}, // entry @ 100*(1+slip)
+		{101, 101, 101, 101},
+		{101, 101, 101, 101}, // SELL fill @ open=101*(1-slip)
+	}, start)
+	strat := newFakeStrategy([]pkgstrategy.SignalAction{
+		pkgstrategy.SignalBuy,
+		pkgstrategy.SignalHold,
+		pkgstrategy.SignalSell,
+	}, 0, 0, 1000)
+	cfg := EngineConfig{
+		Strategy:   strat,
+		Datasource: &sliceDS{bars: bars},
+		Simulator: SimulatorConfig{
+			InitialBalance: 100_000,
+			FeeRate:        0.0,
+			SlippageBps:    0,
+		},
+	}
+	res, err := NewEngine(cfg).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(res.Trades))
+	}
+	if res.Trades[0].Reason != ExitReasonSignal {
+		t.Errorf("expected signal exit, got %s", res.Trades[0].Reason)
+	}
+	if res.Trades[0].NetPnL <= 0 {
+		t.Errorf("expected profit on price up, got %.4f", res.Trades[0].NetPnL)
+	}
+}
+
+func TestSimulator_EODForceClose(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bars := mkBars([][4]float64{
+		{100, 100, 100, 100},
+		{100, 100, 100, 100},
+		{100, 100, 100, 100}, // last bar — still holding
+	}, start)
+	strat := newFakeStrategy([]pkgstrategy.SignalAction{pkgstrategy.SignalBuy}, 0, 0, 1000)
+	cfg := EngineConfig{
+		Strategy:   strat,
+		Datasource: &sliceDS{bars: bars},
+		Simulator: SimulatorConfig{
+			InitialBalance: 100_000,
+			FeeRate:        0.0,
+			SlippageBps:    0,
+		},
+	}
+	res, err := NewEngine(cfg).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Trades) != 1 {
+		t.Fatalf("expected 1 EOD trade, got %d", len(res.Trades))
+	}
+	if res.Trades[0].Reason != ExitReasonEOD {
+		t.Errorf("expected EOD exit, got %s", res.Trades[0].Reason)
+	}
+}
+
+func TestSimulator_FeeAndSlippageReduceProfit(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bars := mkBars([][4]float64{
+		{100, 100, 100, 100},
+		{100, 100, 100, 100}, // buy fill
+		{102, 102, 102, 102}, // tp likely hit since high>=tp
+	}, start)
+	strat := newFakeStrategy([]pkgstrategy.SignalAction{pkgstrategy.SignalBuy}, 0.5, 5, 1000)
+
+	// no fee / slip
+	rNo, err := NewEngine(EngineConfig{
+		Strategy:   newFakeStrategy([]pkgstrategy.SignalAction{pkgstrategy.SignalBuy}, 0.5, 5, 1000),
+		Datasource: &sliceDS{bars: bars},
+		Simulator:  SimulatorConfig{InitialBalance: 100_000},
+	}).Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rWith, err := NewEngine(EngineConfig{
+		Strategy:   strat,
+		Datasource: &sliceDS{bars: bars},
+		Simulator:  SimulatorConfig{InitialBalance: 100_000, FeeRate: 0.0015, SlippageBps: 10},
+	}).Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rNo.Trades) != 1 || len(rWith.Trades) != 1 {
+		t.Fatalf("expected one trade each, got no=%d with=%d", len(rNo.Trades), len(rWith.Trades))
+	}
+	if rWith.Trades[0].NetPnL >= rNo.Trades[0].NetPnL {
+		t.Errorf("fees/slippage should reduce P&L: no=%.4f with=%.4f",
+			rNo.Trades[0].NetPnL, rWith.Trades[0].NetPnL)
+	}
+}
+
+func TestEngine_NoStrategy(t *testing.T) {
+	_, err := NewEngine(EngineConfig{}).Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error for missing strategy")
+	}
+}
+
+func TestEngine_NoDatasource(t *testing.T) {
+	_, err := NewEngine(EngineConfig{Strategy: newFakeStrategy(nil, 0, 0, 0)}).Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error for missing datasource")
+	}
+}
+
+func TestEngine_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	bars := mkBars([][4]float64{{100, 100, 100, 100}, {100, 100, 100, 100}}, time.Now())
+	_, err := NewEngine(EngineConfig{
+		Strategy:   newFakeStrategy(nil, 0, 0, 1000),
+		Datasource: &sliceDS{bars: bars},
+		Simulator:  SimulatorConfig{InitialBalance: 100_000},
+	}).Run(ctx)
+	if err == nil {
+		t.Fatal("expected context cancel error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Logf("non-canonical error: %v", err)
+	}
+}

--- a/pkg/backtest/portfolio.go
+++ b/pkg/backtest/portfolio.go
@@ -1,0 +1,114 @@
+package backtest
+
+import "time"
+
+// Position represents one open long position.
+type Position struct {
+	Symbol     string
+	EntryTime  time.Time
+	EntryPrice float64 // executed price after slippage
+	Quantity   float64
+	Notional   float64 // entry price * quantity (post-slippage)
+	EntryFee   float64
+	EntrySlip  float64 // entry slippage cost in JPY
+	TPPrice    float64 // 0 = disabled
+	SLPrice    float64 // 0 = disabled
+	BarsHeld   int
+}
+
+// MarkValue returns the mark-to-market notional of the position at price p.
+func (pos Position) MarkValue(p float64) float64 {
+	return pos.Quantity * p
+}
+
+// Portfolio tracks cash, an optional open long position, equity history, and
+// completed trades.
+type Portfolio struct {
+	cash     float64
+	peak     float64 // peak equity for drawdown tracking
+	position *Position
+	trades   []Trade
+	equity   []EquityPoint
+}
+
+// NewPortfolio creates a portfolio seeded with initial cash.
+func NewPortfolio(initialCash float64) *Portfolio {
+	return &Portfolio{
+		cash: initialCash,
+		peak: initialCash,
+	}
+}
+
+// Cash returns realized cash.
+func (p *Portfolio) Cash() float64 { return p.cash }
+
+// Position returns a pointer to the open position or nil.
+func (p *Portfolio) Position() *Position { return p.position }
+
+// Trades returns the list of completed trades (live slice, do not mutate).
+func (p *Portfolio) Trades() []Trade { return p.trades }
+
+// Equity returns the equity curve (live slice, do not mutate).
+func (p *Portfolio) Equity() []EquityPoint { return p.equity }
+
+// MarkToMarket records an equity sample at price p / time t.
+func (p *Portfolio) MarkToMarket(t time.Time, price float64) {
+	eq := p.cash
+	if p.position != nil {
+		eq += p.position.MarkValue(price)
+	}
+	if eq > p.peak {
+		p.peak = eq
+	}
+	dd := 0.0
+	if p.peak > 0 {
+		dd = (eq - p.peak) / p.peak
+	}
+	p.equity = append(p.equity, EquityPoint{
+		Timestamp: t,
+		Cash:      p.cash,
+		Equity:    eq,
+		Drawdown:  dd,
+	})
+}
+
+// OpenLong opens a long position. Caller is responsible for slippage / fee
+// calculation; we only update cash and position state here.
+func (p *Portfolio) OpenLong(pos Position) {
+	p.position = &pos
+	p.cash -= pos.Notional + pos.EntryFee + pos.EntrySlip
+}
+
+// CloseLong closes the open position at exitPrice with the given fee/slippage.
+// Returns the recorded Trade. Panics if no position is open.
+func (p *Portfolio) CloseLong(exitTime time.Time, exitPrice, exitFee, exitSlip float64, reason ExitReason) Trade {
+	if p.position == nil {
+		panic("backtest: CloseLong with no open position")
+	}
+	pos := p.position
+	gross := (exitPrice - pos.EntryPrice) * pos.Quantity
+	totalFee := pos.EntryFee + exitFee
+	totalSlip := pos.EntrySlip + exitSlip
+	net := gross - totalFee - totalSlip
+	exitProceeds := exitPrice * pos.Quantity
+	p.cash += exitProceeds - exitFee - exitSlip
+	tr := Trade{
+		Symbol:     pos.Symbol,
+		Side:       SideLong,
+		EntryTime:  pos.EntryTime,
+		EntryPrice: pos.EntryPrice,
+		ExitTime:   exitTime,
+		ExitPrice:  exitPrice,
+		Quantity:   pos.Quantity,
+		Notional:   pos.Notional,
+		GrossPnL:   gross,
+		Fee:        totalFee,
+		Slippage:   totalSlip,
+		NetPnL:     net,
+		Reason:     reason,
+		HoldBars:   pos.BarsHeld,
+	}
+	p.trades = append(p.trades, tr)
+	p.position = nil
+	return tr
+}

--- a/pkg/backtest/report.go
+++ b/pkg/backtest/report.go
@@ -1,0 +1,210 @@
+package backtest
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+// Summary aggregates trade-level and equity-level statistics.
+type Summary struct {
+	TotalTrades      int
+	Wins             int
+	Losses           int
+	WinRate          float64
+	GrossProfit      float64
+	GrossLoss        float64
+	NetPnL           float64
+	AvgPnL           float64
+	BestTrade        float64
+	WorstTrade       float64
+	ProfitFactor     float64
+	TotalFees        float64
+	TotalSlippage    float64
+	MaxDrawdown      float64 // ratio (e.g. -0.12 = -12 %)
+	MaxDrawdownAbs   float64 // JPY
+	MaxDrawdownAt    time.Time
+	SharpeAnnualised float64 // assumes equity samples are uniform
+	Sortino          float64
+	TPHits           int
+	SLHits           int
+	SignalExits      int
+	EODExits         int
+	ExitReasons      map[ExitReason]int
+	Days             float64
+	ReturnPct        float64 // (finalEquity - initial) / initial * 100
+	MonthlyPnL       []MonthlyPnL
+}
+
+// MonthlyPnL is the realized P&L for a single calendar month.
+type MonthlyPnL struct {
+	Year  int
+	Month time.Month
+	PnL   float64
+}
+
+// ComputeSummary derives a Summary from a Result. It does not mutate r.
+func ComputeSummary(r *Result) Summary {
+	s := Summary{ExitReasons: map[ExitReason]int{}}
+	for _, t := range r.Trades {
+		s.TotalTrades++
+		s.NetPnL += t.NetPnL
+		s.TotalFees += t.Fee
+		s.TotalSlippage += t.Slippage
+		s.ExitReasons[t.Reason]++
+		switch t.Reason {
+		case ExitReasonTP:
+			s.TPHits++
+		case ExitReasonSL:
+			s.SLHits++
+		case ExitReasonSignal:
+			s.SignalExits++
+		case ExitReasonEOD:
+			s.EODExits++
+		}
+		if t.IsWin() {
+			s.Wins++
+			s.GrossProfit += t.NetPnL
+		} else {
+			s.Losses++
+			s.GrossLoss += -t.NetPnL
+		}
+		if t.NetPnL > s.BestTrade {
+			s.BestTrade = t.NetPnL
+		}
+		if t.NetPnL < s.WorstTrade {
+			s.WorstTrade = t.NetPnL
+		}
+	}
+	if s.TotalTrades > 0 {
+		s.WinRate = float64(s.Wins) / float64(s.TotalTrades) * 100.0
+		s.AvgPnL = s.NetPnL / float64(s.TotalTrades)
+	}
+	if s.GrossLoss > 0 {
+		s.ProfitFactor = s.GrossProfit / s.GrossLoss
+	} else if s.GrossProfit > 0 {
+		s.ProfitFactor = math.Inf(1)
+	}
+	if r.InitialCash > 0 {
+		s.ReturnPct = (r.FinalEquity - r.InitialCash) / r.InitialCash * 100.0
+	}
+	if !r.StartTime.IsZero() && !r.EndTime.IsZero() {
+		s.Days = r.EndTime.Sub(r.StartTime).Hours() / 24.0
+	}
+
+	// Drawdown stats from equity curve.
+	for _, p := range r.Equity {
+		if p.Drawdown < s.MaxDrawdown {
+			s.MaxDrawdown = p.Drawdown
+			// Drawdown = (equity - peak) / peak  =>  abs = equity * dd / (1+dd).
+			if 1+p.Drawdown > 0 {
+				s.MaxDrawdownAbs = p.Equity * p.Drawdown / (1 + p.Drawdown)
+			}
+			s.MaxDrawdownAt = p.Timestamp
+		}
+	}
+
+	// Sharpe / Sortino from equity returns.
+	if len(r.Equity) > 2 {
+		rets := equityReturns(r.Equity)
+		s.SharpeAnnualised = annualisedSharpe(rets, len(r.Equity), s.Days)
+		s.Sortino = annualisedSortino(rets, len(r.Equity), s.Days)
+	}
+
+	// Monthly P&L.
+	monthly := map[[2]int]float64{}
+	for _, t := range r.Trades {
+		y, m, _ := t.ExitTime.Date()
+		key := [2]int{y, int(m)}
+		monthly[key] += t.NetPnL
+	}
+	for k, v := range monthly {
+		s.MonthlyPnL = append(s.MonthlyPnL, MonthlyPnL{Year: k[0], Month: time.Month(k[1]), PnL: v})
+	}
+	sort.Slice(s.MonthlyPnL, func(i, j int) bool {
+		a, b := s.MonthlyPnL[i], s.MonthlyPnL[j]
+		if a.Year != b.Year {
+			return a.Year < b.Year
+		}
+		return a.Month < b.Month
+	})
+	return s
+}
+
+// peakAtPoint is unused but retained for future drawdown reconstruction.
+//
+//nolint:unused
+func peakAtPoint(curve []EquityPoint, p EquityPoint) float64 {
+	peak := p.Equity
+	for _, q := range curve {
+		if !q.Timestamp.After(p.Timestamp) && q.Equity > peak {
+			peak = q.Equity
+		}
+	}
+	return peak
+}
+
+func equityReturns(curve []EquityPoint) []float64 {
+	rets := make([]float64, 0, len(curve)-1)
+	for i := 1; i < len(curve); i++ {
+		prev := curve[i-1].Equity
+		if prev <= 0 {
+			continue
+		}
+		rets = append(rets, (curve[i].Equity-prev)/prev)
+	}
+	return rets
+}
+
+func annualisedSharpe(rets []float64, samples int, days float64) float64 {
+	if len(rets) < 2 || days <= 0 {
+		return 0
+	}
+	mean, std := meanStd(rets)
+	if std == 0 {
+		return 0
+	}
+	samplesPerDay := float64(samples) / days
+	return mean / std * math.Sqrt(samplesPerDay*365.0)
+}
+
+func annualisedSortino(rets []float64, samples int, days float64) float64 {
+	if len(rets) < 2 || days <= 0 {
+		return 0
+	}
+	mean, _ := meanStd(rets)
+	var downSum float64
+	var n int
+	for _, r := range rets {
+		if r < 0 {
+			downSum += r * r
+			n++
+		}
+	}
+	if n == 0 {
+		return 0
+	}
+	downStd := math.Sqrt(downSum / float64(n))
+	if downStd == 0 {
+		return 0
+	}
+	samplesPerDay := float64(samples) / days
+	return mean / downStd * math.Sqrt(samplesPerDay*365.0)
+}
+
+func meanStd(xs []float64) (float64, float64) {
+	if len(xs) == 0 {
+		return 0, 0
+	}
+	var sum float64
+	for _, x := range xs {
+		sum += x
+	}
+	mean := sum / float64(len(xs))
+	var ss float64
+	for _, x := range xs {
+		d := x - mean
+		ss += d * d
+	}
+	return mean, math.Sqrt(ss / float64(len(xs)))
+}

--- a/pkg/backtest/report_csv.go
+++ b/pkg/backtest/report_csv.go
@@ -1,0 +1,164 @@
+package backtest
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// WriteCSVReports writes trades.csv, equity.csv, signals.csv, summary.json
+// to dir. dir is created if missing.
+func WriteCSVReports(dir string, r *Result) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	if err := writeTrades(filepath.Join(dir, "trades.csv"), r.Trades); err != nil {
+		return err
+	}
+	if err := writeEquity(filepath.Join(dir, "equity.csv"), r.Equity); err != nil {
+		return err
+	}
+	if err := writeSignals(filepath.Join(dir, "signals.csv"), r.SignalCounts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeTrades(path string, trades []Trade) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	if err := w.Write([]string{
+		"entry_time", "exit_time", "symbol", "side", "entry_price", "exit_price",
+		"quantity", "notional", "gross_pnl", "fee", "slippage", "net_pnl",
+		"reason", "hold_bars",
+	}); err != nil {
+		return err
+	}
+	for _, t := range trades {
+		if err := w.Write([]string{
+			t.EntryTime.Format(time.RFC3339Nano),
+			t.ExitTime.Format(time.RFC3339Nano),
+			t.Symbol,
+			string(t.Side),
+			ftoa(t.EntryPrice),
+			ftoa(t.ExitPrice),
+			ftoa(t.Quantity),
+			ftoa(t.Notional),
+			ftoa(t.GrossPnL),
+			ftoa(t.Fee),
+			ftoa(t.Slippage),
+			ftoa(t.NetPnL),
+			string(t.Reason),
+			strconv.Itoa(t.HoldBars),
+		}); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+func writeEquity(path string, eq []EquityPoint) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	if err := w.Write([]string{"timestamp", "cash", "equity", "drawdown"}); err != nil {
+		return err
+	}
+	for _, p := range eq {
+		if err := w.Write([]string{
+			p.Timestamp.Format(time.RFC3339Nano),
+			ftoa(p.Cash),
+			ftoa(p.Equity),
+			ftoa(p.Drawdown),
+		}); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+func writeSignals(path string, counts []SignalCount) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	sort.Slice(counts, func(i, j int) bool { return counts[i].Count > counts[j].Count })
+	w := csv.NewWriter(f)
+	if err := w.Write([]string{"action", "reason", "count"}); err != nil {
+		return err
+	}
+	for _, c := range counts {
+		if err := w.Write([]string{c.Action, c.Reason, strconv.Itoa(c.Count)}); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+// PrintSummary writes a human-readable text summary to w.
+func PrintSummary(w io.Writer, r *Result) {
+	s := r.Summary
+	_, _ = fmt.Fprintf(w, "===================================================\n")
+	_, _ = fmt.Fprintf(w, " Backtest Result: %s / %s\n", r.StrategyName, r.Symbol)
+	_, _ = fmt.Fprintf(w, "===================================================\n")
+	_, _ = fmt.Fprintf(w, "Period:         %s ～ %s (%.1f days)\n",
+		r.StartTime.Format("2006-01-02"), r.EndTime.Format("2006-01-02"), s.Days)
+	_, _ = fmt.Fprintf(w, "Bars:           %d\n", r.Bars)
+	_, _ = fmt.Fprintf(w, "Trades closed:  %d  (TP %d  /  SL %d  /  Signal %d  /  EOD %d)\n",
+		s.TotalTrades, s.TPHits, s.SLHits, s.SignalExits, s.EODExits)
+	_, _ = fmt.Fprintf(w, "\n[ P&L ]\n")
+	_, _ = fmt.Fprintf(w, "  Net P&L:      %+.2f JPY  (%.2f %% on %.0f JPY)\n",
+		s.NetPnL, s.ReturnPct, r.InitialCash)
+	if s.TotalTrades > 0 {
+		_, _ = fmt.Fprintf(w, "  Win rate:     %.1f %%  (%d W / %d L)\n", s.WinRate, s.Wins, s.Losses)
+		_, _ = fmt.Fprintf(w, "  Avg / trade:  %+.2f JPY\n", s.AvgPnL)
+		_, _ = fmt.Fprintf(w, "  Best / Worst: %+.2f / %+.2f JPY\n", s.BestTrade, s.WorstTrade)
+		_, _ = fmt.Fprintf(w, "  Profit factor:%.3f\n", s.ProfitFactor)
+	}
+	_, _ = fmt.Fprintf(w, "\n[ Risk ]\n")
+	_, _ = fmt.Fprintf(w, "  Max drawdown: %.2f %%  (%.2f JPY)\n", s.MaxDrawdown*100.0, s.MaxDrawdownAbs)
+	if !s.MaxDrawdownAt.IsZero() {
+		_, _ = fmt.Fprintf(w, "  DD timestamp: %s\n", s.MaxDrawdownAt.Format(time.RFC3339))
+	}
+	_, _ = fmt.Fprintf(w, "  Sharpe (ann): %.3f\n", s.SharpeAnnualised)
+	_, _ = fmt.Fprintf(w, "  Sortino:      %.3f\n", s.Sortino)
+	_, _ = fmt.Fprintf(w, "\n[ Costs ]\n")
+	_, _ = fmt.Fprintf(w, "  Fees paid:    %.2f JPY\n", s.TotalFees)
+	_, _ = fmt.Fprintf(w, "  Slippage:     %.2f JPY\n", s.TotalSlippage)
+	if len(s.MonthlyPnL) > 0 {
+		_, _ = fmt.Fprintf(w, "\n[ Monthly P&L ]\n")
+		for _, m := range s.MonthlyPnL {
+			_, _ = fmt.Fprintf(w, "  %04d-%02d: %+.2f JPY\n", m.Year, int(m.Month), m.PnL)
+		}
+	}
+	if len(r.SignalCounts) > 0 {
+		_, _ = fmt.Fprintf(w, "\n[ Top signal reasons ]\n")
+		sorted := make([]SignalCount, len(r.SignalCounts))
+		copy(sorted, r.SignalCounts)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Count > sorted[j].Count })
+		for i, c := range sorted {
+			if i >= 8 {
+				break
+			}
+			_, _ = fmt.Fprintf(w, "  %-6s %-32s %d\n", c.Action, c.Reason, c.Count)
+		}
+	}
+}
+
+func ftoa(v float64) string { return strconv.FormatFloat(v, 'f', -1, 64) }

--- a/pkg/backtest/simulator.go
+++ b/pkg/backtest/simulator.go
@@ -1,0 +1,173 @@
+package backtest
+
+import (
+	"math"
+	"time"
+
+	pkgstrategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+// Simulator implements the fill model. It is stateful so the engine can call
+// Step() once per Bar without owning portfolio internals directly.
+type Simulator struct {
+	cfg       SimulatorConfig
+	portfolio *Portfolio
+}
+
+// NewSimulator returns a Simulator wired to portfolio.
+func NewSimulator(cfg SimulatorConfig, portfolio *Portfolio) *Simulator {
+	if cfg.SameBarRule == "" {
+		cfg.SameBarRule = SameBarSLPriority
+	}
+	return &Simulator{cfg: cfg, portfolio: portfolio}
+}
+
+// Portfolio returns the underlying portfolio (read-only convenience).
+func (s *Simulator) Portfolio() *Portfolio { return s.portfolio }
+
+// HandleExit checks whether the current Bar triggers TP/SL on the open
+// position. Must be called BEFORE evaluating new signals on the same bar so
+// that TP/SL are honored ahead of any new entry.
+//
+// It returns true when the position was closed.
+func (s *Simulator) HandleExit(bar Bar) (Trade, bool) {
+	pos := s.portfolio.Position()
+	if pos == nil {
+		return Trade{}, false
+	}
+	pos.BarsHeld++
+
+	tpHit := pos.TPPrice > 0 && bar.High >= pos.TPPrice
+	slHit := pos.SLPrice > 0 && bar.Low <= pos.SLPrice
+
+	var (
+		exitPrice float64
+		reason    ExitReason
+		hit       bool
+	)
+	switch {
+	case tpHit && slHit:
+		// Same-bar collision; resolve via configured rule.
+		switch s.cfg.SameBarRule {
+		case SameBarTPPriority:
+			exitPrice, reason, hit = pos.TPPrice, ExitReasonTP, true
+		case SameBarSkip:
+			// Treat as no exit on this bar.
+			hit = false
+		default:
+			exitPrice, reason, hit = pos.SLPrice, ExitReasonSL, true
+		}
+	case tpHit:
+		exitPrice, reason, hit = pos.TPPrice, ExitReasonTP, true
+	case slHit:
+		exitPrice, reason, hit = pos.SLPrice, ExitReasonSL, true
+	}
+	if !hit {
+		return Trade{}, false
+	}
+	exitProceeds := exitPrice * pos.Quantity
+	exitSlip := exitProceeds * s.cfg.SlippageBps / 10_000.0
+	exitFee := exitProceeds * s.cfg.FeeRate
+	tr := s.portfolio.CloseLong(bar.Timestamp, exitPrice, exitFee, exitSlip, reason)
+	return tr, true
+}
+
+// HandleSignal applies a strategy Signal to the portfolio. nextOpen is the
+// open price of the NEXT bar — entries fill there to prevent lookahead bias.
+// When isLastBar is true and there is still an open position, it is closed
+// at bar.Close (fee+slippage applied).
+func (s *Simulator) HandleSignal(bar, nextBar Bar, signal *pkgstrategy.Signal, hasNext bool, strat pkgstrategy.Strategy) (Trade, bool) {
+	if signal == nil {
+		return Trade{}, false
+	}
+	switch signal.Action {
+	case pkgstrategy.SignalBuy:
+		if s.portfolio.Position() != nil {
+			// Already long; ignore.
+			return Trade{}, false
+		}
+		if !hasNext {
+			// Cannot fill without a next bar.
+			return Trade{}, false
+		}
+		entryRaw := nextBar.Open
+		// Slippage: pay above the open.
+		slipPct := s.cfg.SlippageBps / 10_000.0
+		entryPrice := entryRaw * (1.0 + slipPct)
+		notionalReq := strat.GetBaseNotional(bar.Symbol)
+		if notionalReq <= 0 {
+			return Trade{}, false
+		}
+		// Volume sanity check (optional).
+		if s.cfg.MinVolumeRatio > 0 && nextBar.Volume > 0 {
+			required := s.cfg.MinVolumeRatio * notionalReq / entryPrice
+			if nextBar.Volume < required {
+				return Trade{}, false
+			}
+		}
+		// Cash check.
+		if s.portfolio.Cash() < notionalReq*(1.0+s.cfg.FeeRate+slipPct) {
+			return Trade{}, false
+		}
+		qty := notionalReq / entryPrice
+		notionalActual := entryPrice * qty
+		entryFee := notionalActual * s.cfg.FeeRate
+		entrySlip := notionalActual * slipPct
+		pos := Position{
+			Symbol:     bar.Symbol,
+			EntryTime:  nextBar.Timestamp,
+			EntryPrice: entryPrice,
+			Quantity:   qty,
+			Notional:   notionalActual,
+			EntryFee:   entryFee,
+			EntrySlip:  entrySlip,
+			TPPrice:    strat.GetTakeProfitPrice(entryPrice),
+			SLPrice:    strat.GetStopLossPrice(entryPrice),
+		}
+		s.portfolio.OpenLong(pos)
+		// Notify strategy so cooldown / daily counter advance.
+		strat.RecordTrade()
+
+	case pkgstrategy.SignalSell:
+		if s.portfolio.Position() == nil {
+			return Trade{}, false
+		}
+		if !hasNext {
+			return Trade{}, false
+		}
+		exitRaw := nextBar.Open
+		slipPct := s.cfg.SlippageBps / 10_000.0
+		exitPrice := exitRaw * (1.0 - slipPct)
+		pos := s.portfolio.Position()
+		exitProceeds := exitPrice * pos.Quantity
+		exitSlip := exitProceeds * slipPct
+		exitFee := exitProceeds * s.cfg.FeeRate
+		tr := s.portfolio.CloseLong(nextBar.Timestamp, exitPrice, exitFee, exitSlip, ExitReasonSignal)
+		strat.RecordTrade()
+		return tr, true
+	}
+	return Trade{}, false
+}
+
+// ForceClose closes any open position at price (no slippage adjustment beyond
+// fee). Used at end-of-data to liquidate so equity is comparable.
+func (s *Simulator) ForceClose(t time.Time, price float64) (Trade, bool) {
+	if s.portfolio.Position() == nil {
+		return Trade{}, false
+	}
+	exitProceeds := price * s.portfolio.Position().Quantity
+	exitFee := exitProceeds * s.cfg.FeeRate
+	tr := s.portfolio.CloseLong(t, price, exitFee, 0, ExitReasonEOD)
+	return tr, true
+}
+
+// roundLot rounds qty down to the nearest multiple of step. step <= 0 means
+// no rounding.
+//
+//nolint:unused // reserved for future per-symbol lot-size handling
+func roundLot(qty, step float64) float64 {
+	if step <= 0 {
+		return qty
+	}
+	return math.Floor(qty/step) * step
+}

--- a/pkg/backtest/types.go
+++ b/pkg/backtest/types.go
@@ -1,0 +1,113 @@
+// Package backtest provides a deterministic, strategy-agnostic backtesting
+// engine for the gogocoin trading framework.
+//
+// The engine replays historical market data through a strategy.Strategy
+// implementation, simulates fills with a configurable fee/slippage model,
+// and produces detailed performance reports (P&L, win rate, drawdown,
+// Sharpe, profit factor, etc.).
+//
+// It is intentionally decoupled from the live trading engine so that the
+// same Strategy code path can be validated against historical data before
+// being deployed to production.
+package backtest
+
+import "time"
+
+// Bar represents a single OHLCV candle. The backtest engine processes one
+// Bar per step in chronological order.
+type Bar struct {
+	Symbol    string
+	Timestamp time.Time
+	Open      float64
+	High      float64
+	Low       float64
+	Close     float64
+	Volume    float64
+}
+
+// Side is the direction of an open position. The backtest is long-only:
+// SideLong is opened by a strategy BUY signal and closed by SELL / TP / SL.
+type Side string
+
+const (
+	SideLong Side = "LONG"
+)
+
+// ExitReason describes why a position was closed.
+type ExitReason string
+
+const (
+	ExitReasonSignal ExitReason = "signal" // strategy emitted SELL
+	ExitReasonTP     ExitReason = "tp"     // take-profit hit
+	ExitReasonSL     ExitReason = "sl"     // stop-loss hit
+	ExitReasonEOD    ExitReason = "end"    // end of data while still holding
+)
+
+// Trade is a single completed round-trip (entry + exit).
+type Trade struct {
+	Symbol     string
+	Side       Side
+	EntryTime  time.Time
+	EntryPrice float64
+	ExitTime   time.Time
+	ExitPrice  float64
+	Quantity   float64 // base asset quantity
+	Notional   float64 // JPY notional at entry (price * qty before slippage)
+	GrossPnL   float64 // (exit - entry) * qty
+	Fee        float64 // round-trip fee
+	Slippage   float64 // total slippage cost (entry + exit)
+	NetPnL     float64 // GrossPnL - Fee - Slippage
+	Reason     ExitReason
+	HoldBars   int
+}
+
+// IsWin returns true when NetPnL is strictly positive.
+func (t Trade) IsWin() bool { return t.NetPnL > 0 }
+
+// EquityPoint is one sample of the equity curve, taken once per Bar.
+type EquityPoint struct {
+	Timestamp time.Time
+	Cash      float64 // realized cash (JPY)
+	Equity    float64 // mark-to-market equity (cash + unrealized)
+	Drawdown  float64 // peak-to-current drawdown ratio (negative or zero)
+}
+
+// SignalCount summarizes how often each (action, reason) pair was emitted.
+// Used for diagnostic output ("why did the strategy not enter more trades?").
+type SignalCount struct {
+	Action string
+	Reason string
+	Count  int
+}
+
+// SameBarRule controls how a single Bar that contains both TP and SL prices
+// is resolved. Real-life ordering is unknown, so the user picks a model.
+type SameBarRule string
+
+const (
+	SameBarSLPriority SameBarRule = "sl_priority" // pessimistic (default)
+	SameBarTPPriority SameBarRule = "tp_priority"
+	SameBarSkip       SameBarRule = "skip" // close at Bar.Close, no TP/SL
+)
+
+// SimulatorConfig controls the fill model.
+type SimulatorConfig struct {
+	InitialBalance float64     // starting cash in JPY
+	FeeRate        float64     // taker fee, e.g. 0.0015 = 0.15 %
+	SlippageBps    float64     // slippage in basis points (1 bp = 0.01 %)
+	SameBarRule    SameBarRule // how to resolve same-bar TP+SL
+	// MinVolumeRatio rejects fills when the bar volume is below
+	// MinVolumeRatio * (notional / price). 0 disables the check.
+	MinVolumeRatio float64
+}
+
+// DefaultSimulatorConfig returns a conservative default configuration.
+func DefaultSimulatorConfig() SimulatorConfig {
+	return SimulatorConfig{
+		InitialBalance: 100_000,
+		FeeRate:        0.0015,
+		SlippageBps:    5,
+		SameBarRule:    SameBarSLPriority,
+		MinVolumeRatio: 0,
+	}
+}


### PR DESCRIPTION
## Summary
- add reusable backtest implementation under `pkg/backtest`
- add backtest CLI entrypoint under `cmd/backtest`
- add default backtest config and docs (`configs/backtest.yaml`, `docs/BACKTEST.md`)
- add Makefile targets: `backtest`, `backtest-grid`, `backtest-walkforward`

## Why
Issue #78 asks to add backtesting support in gogocoin. Until now this lived only in `my-gogocoin`.

## Notes
- current command registers `scalping` strategy via blank import in `cmd/backtest/main.go`
- implementation is copied from the proven `my-gogocoin` backtest engine and moved into shared module path
