### PR TITLE
fix(worker): never silently drop stop-loss and take-profit signals

### DIFF
--- a/internal/adapter/worker/forced_exit_test.go
+++ b/internal/adapter/worker/forced_exit_test.go
@@ -1,0 +1,157 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bmf-san/gogocoin/internal/domain"
+	strategy "github.com/bmf-san/gogocoin/pkg/strategy"
+)
+
+// buyStrategy always emits a BUY so that entry-suppression can be exercised.
+type buyStrategy struct {
+	mockStrategyWithConfig
+}
+
+func (b *buyStrategy) Analyze([]strategy.MarketData) (*strategy.Signal, error) {
+	return &strategy.Signal{
+		Symbol:   "XRP_JPY",
+		Action:   strategy.SignalBuy,
+		Strength: 1.0,
+	}, nil
+}
+
+func testSignal(action strategy.SignalAction) *strategy.Signal {
+	return &strategy.Signal{
+		Symbol:    "XRP_JPY",
+		Action:    action,
+		Strength:  1.0,
+		Price:     100.0,
+		Timestamp: time.Now(),
+	}
+}
+
+// A forced exit protects an open position, so a full channel must not cause it
+// to be discarded: the send waits for the consumer to catch up.
+func TestSendSignal_ForcedExitWaitsForRoomInsteadOfDropping(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"stop_loss_pct": 1.0})
+	ch := make(chan *strategy.Signal, 1)
+	w.signalCh = ch
+	ch <- testSignal(strategy.SignalBuy) // fill the buffer
+
+	// Drain shortly after, simulating a consumer that is briefly behind.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		<-ch
+	}()
+
+	if !w.sendSignal(context.Background(), testSignal(strategy.SignalSell), true) {
+		t.Fatal("forced-exit signal was not enqueued; it must never be silently dropped")
+	}
+	if got := atomic.LoadInt64(&w.droppedSignals); got != 0 {
+		t.Fatalf("expected no dropped signals, got %d", got)
+	}
+}
+
+// Ordinary strategy signals are regenerated on the next tick, so dropping them
+// under back-pressure is still the correct behavior.
+func TestSendSignal_OrdinarySignalIsDroppedWhenChannelFull(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"stop_loss_pct": 1.0})
+	ch := make(chan *strategy.Signal, 1)
+	w.signalCh = ch
+	ch <- testSignal(strategy.SignalBuy)
+
+	if w.sendSignal(context.Background(), testSignal(strategy.SignalSell), false) {
+		t.Fatal("ordinary signal should be dropped when the channel is full")
+	}
+	if got := atomic.LoadInt64(&w.droppedSignals); got != 1 {
+		t.Fatalf("expected dropped_signals=1, got %d", got)
+	}
+}
+
+// Waiting for room must not outlive shutdown.
+func TestSendSignal_ForcedExitAbortsOnContextCancel(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"stop_loss_pct": 1.0})
+	ch := make(chan *strategy.Signal, 1)
+	w.signalCh = ch
+	ch <- testSignal(strategy.SignalBuy)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan bool, 1)
+	go func() { done <- w.sendSignal(ctx, testSignal(strategy.SignalSell), true) }()
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("expected send to fail after context cancellation")
+		}
+	case <-time.After(ForcedExitSendTimeout):
+		t.Fatal("sendSignal did not return after context cancellation")
+	}
+}
+
+// A failed position read means stop-loss state is unknown; it must surface as an
+// error rather than being reported as "no exit required".
+func TestForcedExitSignal_PositionReadErrorIsReported(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"stop_loss_pct": 1.0, "take_profit_pct": 2.0})
+	w.SetPositionReader(&mockPositionReader{err: errors.New("database is locked")})
+
+	sig, err := w.forcedExitSignal("XRP_JPY", 100.0)
+	if err == nil {
+		t.Fatal("expected an error when open positions cannot be read")
+	}
+	if sig != nil {
+		t.Fatalf("expected no signal on read failure, got %+v", sig)
+	}
+	if got := atomic.LoadInt64(&w.positionReadFailures); got != 0 {
+		t.Fatalf("counter should only advance when the failure is reported, got %d", got)
+	}
+
+	w.reportPositionReadFailure("XRP_JPY", err)
+	if got := atomic.LoadInt64(&w.positionReadFailures); got != 1 {
+		t.Fatalf("expected position_read_failures=1, got %d", got)
+	}
+}
+
+// While positions cannot be read the stop-loss cannot be enforced, so opening a
+// new position would add risk that cannot be managed.
+func TestExecuteStrategy_SuppressesBuyWhenPositionReadFails(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"stop_loss_pct": 1.0})
+	ch := make(chan *strategy.Signal, 10)
+	w.signalCh = ch
+	w.strategy = &buyStrategy{mockStrategyWithConfig{cfg: map[string]any{"stop_loss_pct": 1.0}}}
+	w.SetPositionReader(&mockPositionReader{err: errors.New("database is locked")})
+
+	w.executeStrategy(context.Background(), &domain.MarketData{Symbol: "XRP_JPY", Price: 100.0}, nil)
+
+	select {
+	case sig := <-ch:
+		t.Fatalf("BUY must be suppressed while position state is unreadable, got %+v", sig)
+	default:
+	}
+	if got := atomic.LoadInt64(&w.positionReadFailures); got != 1 {
+		t.Fatalf("expected position_read_failures=1, got %d", got)
+	}
+}
+
+// The same failure must not block an exit: a SELL still goes through.
+func TestExecuteStrategy_AllowsSellWhenPositionReadFails(t *testing.T) {
+	w := newTestStrategyWorker(t, map[string]any{"stop_loss_pct": 1.0})
+	ch := make(chan *strategy.Signal, 10)
+	w.signalCh = ch
+	w.SetPositionReader(&mockPositionReader{err: errors.New("database is locked")})
+
+	signal := testSignal(strategy.SignalSell)
+	w.logger.LogStrategySignal("test", signal.Symbol, string(signal.Action), signal.Strength, nil)
+	if !w.sendSignal(context.Background(), signal, false) {
+		t.Fatal("SELL should be enqueued even while position reads are failing")
+	}
+}

--- a/internal/adapter/worker/stop_loss_test.go
+++ b/internal/adapter/worker/stop_loss_test.go
@@ -71,8 +71,8 @@ func newTestStrategyWorker(t *testing.T, cfg map[string]any) *StrategyWorker {
 func TestCheckStopLoss_NoPositionReader(t *testing.T) {
 	w := newTestStrategyWorker(t, map[string]any{"stop_loss_pct": 1.0})
 	// No position reader set — must return nil
-	if got := w.checkStopLoss("XRP_JPY", 220.0); got != nil {
-		t.Fatalf("expected nil when no position reader, got %+v", got)
+	if got, err := w.checkStopLoss("XRP_JPY", 220.0); got != nil || err != nil {
+		t.Fatalf("expected nil when no position reader, got %+v (err=%v)", got, err)
 	}
 }
 
@@ -80,8 +80,8 @@ func TestCheckStopLoss_NoOpenPositions(t *testing.T) {
 	w := newTestStrategyWorker(t, map[string]any{"stop_loss_pct": 1.0})
 	w.SetPositionReader(&mockPositionReader{positions: []domain.Position{}})
 
-	if got := w.checkStopLoss("XRP_JPY", 220.0); got != nil {
-		t.Fatalf("expected nil for empty positions, got %+v", got)
+	if got, err := w.checkStopLoss("XRP_JPY", 220.0); got != nil || err != nil {
+		t.Fatalf("expected nil for empty positions, got %+v (err=%v)", got, err)
 	}
 }
 
@@ -94,8 +94,8 @@ func TestCheckStopLoss_StopLossNotTriggered(t *testing.T) {
 	})
 
 	// 1% below 230.0 = 227.70; current price 228.0 is above stop → no trigger
-	if got := w.checkStopLoss("XRP_JPY", 228.0); got != nil {
-		t.Fatalf("stop loss should not trigger at 228.0 (stop=227.7), got %+v", got)
+	if got, err := w.checkStopLoss("XRP_JPY", 228.0); got != nil || err != nil {
+		t.Fatalf("stop loss should not trigger at 228.0 (stop=227.7), got %+v (err=%v)", got, err)
 	}
 }
 
@@ -108,7 +108,10 @@ func TestCheckStopLoss_StopLossTriggered(t *testing.T) {
 	})
 
 	// 1% below 230.0 = 227.70; current price 227.5 is below stop → trigger
-	got := w.checkStopLoss("XRP_JPY", 227.5)
+	got, err := w.checkStopLoss("XRP_JPY", 227.5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got == nil {
 		t.Fatal("expected SELL signal when stop loss triggers, got nil")
 	}
@@ -132,7 +135,10 @@ func TestCheckStopLoss_ExactlyAtStopPrice(t *testing.T) {
 	})
 
 	// exactly at stop price (230 * 0.99 = 227.7) must trigger
-	got := w.checkStopLoss("XRP_JPY", 227.7)
+	got, err := w.checkStopLoss("XRP_JPY", 227.7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got == nil {
 		t.Fatal("expected SELL signal at exact stop price, got nil")
 	}
@@ -147,8 +153,8 @@ func TestCheckStopLoss_ZeroStopLossPct(t *testing.T) {
 	})
 
 	// stop_loss_pct=0 means disabled — should not trigger regardless of price
-	if got := w.checkStopLoss("XRP_JPY", 100.0); got != nil {
-		t.Fatalf("stop loss should be disabled when pct=0, got %+v", got)
+	if got, err := w.checkStopLoss("XRP_JPY", 100.0); got != nil || err != nil {
+		t.Fatalf("stop loss should be disabled when pct=0, got %+v (err=%v)", got, err)
 	}
 }
 
@@ -162,7 +168,10 @@ func TestCheckStopLoss_MultiplePositions_OnlyOneBreached(t *testing.T) {
 	})
 
 	// 226.5 is below 229 stop (226.71) → should trigger on first position
-	got := w.checkStopLoss("XRP_JPY", 226.5)
+	got, err := w.checkStopLoss("XRP_JPY", 226.5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got == nil {
 		t.Fatal("expected SELL signal, got nil")
 	}
@@ -183,7 +192,10 @@ func TestCheckStopLoss_PartialPosition_Triggered(t *testing.T) {
 	})
 
 	// 1% below 229.01 = 226.7199; current price 226.29 is below stop → trigger
-	got := w.checkStopLoss("XRP_JPY", 226.29)
+	got, err := w.checkStopLoss("XRP_JPY", 226.29)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got == nil {
 		t.Fatal("expected SELL signal for PARTIAL position below stop price, got nil")
 	}

--- a/internal/adapter/worker/strategy_worker.go
+++ b/internal/adapter/worker/strategy_worker.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -26,6 +27,14 @@ const (
 	// (stop-loss / take-profit) SELL signals for the same symbol. This prevents
 	// duplicate orders while still retrying if the first attempt failed.
 	ForcedExitCooldown = 30 * time.Second
+
+	// ForcedExitSendTimeout bounds how long a forced-exit (stop-loss /
+	// take-profit) SELL signal waits for room on the signal channel before it
+	// is finally given up on. Ordinary strategy signals are dropped immediately
+	// when the channel is full because the next tick regenerates them, but a
+	// forced exit protects an open position and must not be discarded just
+	// because the consumer is momentarily behind.
+	ForcedExitSendTimeout = 5 * time.Second
 )
 
 // symbolHistory holds market data history for a single symbol with its own lock
@@ -66,7 +75,8 @@ type StrategyWorker struct {
 	processingPool chan struct{} // Semaphore to limit concurrent processing goroutines
 
 	// Metrics
-	droppedSignals int64 // Atomic counter for dropped signals
+	droppedSignals       int64 // Atomic counter for dropped signals
+	positionReadFailures int64 // Atomic counter for failed open-position reads (SL/TP blind spots)
 
 	// Deduplication: track last sent signal action per symbol to avoid flooding the channel
 	// with identical signals on every tick during a sustained trend
@@ -358,17 +368,21 @@ func (w *StrategyWorker) SetPositionReader(r PositionReader) {
 }
 
 // checkStopLoss returns a SELL signal when the current price has fallen below the
-// stop-loss threshold of any open BUY position for the symbol. Returns nil when
-// stop-loss is not triggered or no position reader is configured.
-func (w *StrategyWorker) checkStopLoss(symbol string, currentPrice float64) *strategy.Signal {
+// stop-loss threshold of any open BUY position for the symbol. Returns a nil
+// signal when stop-loss is not triggered or no position reader is configured.
+//
+// A non-nil error means the open positions could not be read, so stop-loss
+// state is UNKNOWN for this tick. Callers must treat that as a risk-management
+// outage rather than as "stop-loss not triggered": an open position may be
+// breaching its stop without us being able to see it.
+func (w *StrategyWorker) checkStopLoss(symbol string, currentPrice float64) (*strategy.Signal, error) {
 	if w.positionReader == nil || w.strategy == nil {
-		return nil
+		return nil, nil
 	}
 
 	positions, err := w.positionReader.GetOpenPositions(symbol, "BUY")
 	if err != nil {
-		w.logger.Strategy().WithError(err).Warn("Failed to read open positions for stop-loss check")
-		return nil
+		return nil, fmt.Errorf("read open positions for stop-loss check (%s): %w", symbol, err)
 	}
 
 	for i := range positions {
@@ -398,24 +412,26 @@ func (w *StrategyWorker) checkStopLoss(symbol string, currentPrice float64) *str
 					"entry_price": pos.EntryPrice,
 					"stop_price":  stopPrice,
 				},
-			}
+			}, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // checkTakeProfit returns a SELL signal when the current price has risen above the
-// take-profit threshold of any open BUY position for the symbol. Returns nil when
-// take-profit is not triggered or no position reader is configured.
-func (w *StrategyWorker) checkTakeProfit(symbol string, currentPrice float64) *strategy.Signal {
+// take-profit threshold of any open BUY position for the symbol. Returns a nil
+// signal when take-profit is not triggered or no position reader is configured.
+//
+// As with checkStopLoss, a non-nil error means position state is UNKNOWN for
+// this tick and must not be interpreted as "take-profit not triggered".
+func (w *StrategyWorker) checkTakeProfit(symbol string, currentPrice float64) (*strategy.Signal, error) {
 	if w.positionReader == nil || w.strategy == nil {
-		return nil
+		return nil, nil
 	}
 
 	positions, err := w.positionReader.GetOpenPositions(symbol, "BUY")
 	if err != nil {
-		w.logger.Strategy().WithError(err).Warn("Failed to read open positions for take-profit check")
-		return nil
+		return nil, fmt.Errorf("read open positions for take-profit check (%s): %w", symbol, err)
 	}
 
 	for i := range positions {
@@ -445,10 +461,10 @@ func (w *StrategyWorker) checkTakeProfit(symbol string, currentPrice float64) *s
 					"entry_price": pos.EntryPrice,
 					"take_price":  takePrice,
 				},
-			}
+			}, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // processTickBarMode handles a single market data tick when bar aggregation
@@ -566,11 +582,10 @@ func (w *StrategyWorker) processTickBarMode(ctx context.Context, data *domain.Ma
 // remain tick-level. The per-symbol ForcedExitCooldown prevents flooding
 // when an order is still settling.
 func (w *StrategyWorker) dispatchForcedExitIfAny(ctx context.Context, marketData *domain.MarketData) {
-	var sig *strategy.Signal
-	if s := w.checkStopLoss(marketData.Symbol, marketData.Price); s != nil {
-		sig = s
-	} else if s := w.checkTakeProfit(marketData.Symbol, marketData.Price); s != nil {
-		sig = s
+	sig, err := w.forcedExitSignal(marketData.Symbol, marketData.Price)
+	if err != nil {
+		w.reportPositionReadFailure(marketData.Symbol, err)
+		return
 	}
 	if sig == nil {
 		return
@@ -590,19 +605,91 @@ func (w *StrategyWorker) dispatchForcedExitIfAny(ctx context.Context, marketData
 		sig.Strength,
 		sig.Metadata,
 	)
-	select {
-	case w.signalCh <- sig:
-		w.lastSentSignals.Store(sig.Symbol, sig.Action)
+	if w.sendSignal(ctx, sig, true) {
 		w.lastForcedExitAttempt.Store(sig.Symbol, time.Now())
+	}
+}
+
+// forcedExitSignal evaluates stop-loss first (risk priority) and take-profit
+// only when no stop-loss fires. A non-nil error means the position state could
+// not be read and neither check could be performed.
+func (w *StrategyWorker) forcedExitSignal(symbol string, price float64) (*strategy.Signal, error) {
+	slSignal, err := w.checkStopLoss(symbol, price)
+	if err != nil {
+		return nil, err
+	}
+	if slSignal != nil {
+		return slSignal, nil
+	}
+	tpSignal, err := w.checkTakeProfit(symbol, price)
+	if err != nil {
+		return nil, err
+	}
+	return tpSignal, nil
+}
+
+// reportPositionReadFailure logs a position-read outage at ERROR level. While
+// positions cannot be read, stop-loss and take-profit are effectively disabled,
+// so this must be loud enough to alert on rather than a routine warning.
+func (w *StrategyWorker) reportPositionReadFailure(symbol string, err error) {
+	failures := atomic.AddInt64(&w.positionReadFailures, 1)
+	w.logger.Trading().
+		WithError(err).
+		WithField("symbol", symbol).
+		WithField("failure_count", failures).
+		Error("Position read failed — stop-loss/take-profit cannot be evaluated for this tick")
+}
+
+// sendSignal queues a signal for execution, returning true when it was accepted.
+//
+// Ordinary strategy signals are dropped when the channel is full: they are
+// regenerated on the next tick, so blocking the worker would only add latency.
+// Forced exits (stop-loss / take-profit) are different — dropping one leaves a
+// losing position open with no protection — so they fall back to a bounded
+// blocking wait instead of being discarded outright.
+func (w *StrategyWorker) sendSignal(ctx context.Context, signal *strategy.Signal, isForcedExit bool) bool {
+	select {
+	case w.signalCh <- signal:
+		w.lastSentSignals.Store(signal.Symbol, signal.Action)
+		return true
 	case <-ctx.Done():
-		return
+		return false
 	default:
+	}
+
+	if !isForcedExit {
 		droppedCount := atomic.AddInt64(&w.droppedSignals, 1)
 		w.logger.Strategy().
 			WithField("dropped_count", droppedCount).
-			WithField("symbol", sig.Symbol).
-			WithField("action", sig.Action).
-			Warn("Signal channel is full, dropping forced-exit signal")
+			WithField("symbol", signal.Symbol).
+			WithField("action", signal.Action).
+			Warn("Signal channel is full, dropping signal")
+		return false
+	}
+
+	w.logger.Trading().
+		WithField("symbol", signal.Symbol).
+		WithField("action", signal.Action).
+		WithField("timeout", ForcedExitSendTimeout.String()).
+		Warn("Signal channel is full, blocking to enqueue forced-exit signal")
+
+	timer := time.NewTimer(ForcedExitSendTimeout)
+	defer timer.Stop()
+
+	select {
+	case w.signalCh <- signal:
+		w.lastSentSignals.Store(signal.Symbol, signal.Action)
+		return true
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		droppedCount := atomic.AddInt64(&w.droppedSignals, 1)
+		w.logger.Trading().
+			WithField("dropped_count", droppedCount).
+			WithField("symbol", signal.Symbol).
+			WithField("action", signal.Action).
+			Error("Forced-exit signal could not be enqueued before timeout — position remains unprotected")
+		return false
 	}
 }
 
@@ -635,11 +722,21 @@ func (w *StrategyWorker) executeStrategy(ctx context.Context, marketData *domain
 	// Stop-loss is checked first (risk priority); take-profit only when no SL fires.
 	isForcedExit := false
 	if signal.Action != strategy.SignalSell {
-		if slSignal := w.checkStopLoss(marketData.Symbol, marketData.Price); slSignal != nil {
-			signal = slSignal
-			isForcedExit = true
-		} else if tpSignal := w.checkTakeProfit(marketData.Symbol, marketData.Price); tpSignal != nil {
-			signal = tpSignal
+		forced, err := w.forcedExitSignal(marketData.Symbol, marketData.Price)
+		switch {
+		case err != nil:
+			w.reportPositionReadFailure(marketData.Symbol, err)
+			// Position state is unknown, so an existing position's stop-loss
+			// cannot be enforced. Opening a new one would add risk we are
+			// currently unable to manage — hold until reads recover.
+			if signal.Action == strategy.SignalBuy {
+				w.logger.Trading().
+					WithField("symbol", marketData.Symbol).
+					Error("Suppressing BUY signal while position state is unreadable")
+				return
+			}
+		case forced != nil:
+			signal = forced
 			isForcedExit = true
 		}
 	}
@@ -677,23 +774,8 @@ func (w *StrategyWorker) executeStrategy(ctx context.Context, marketData *domain
 		)
 
 		// Send signal to processing queue
-		select {
-		case w.signalCh <- signal:
-			// Record last sent action only on successful send
-			w.lastSentSignals.Store(signal.Symbol, signal.Action)
-			if isForcedExit {
-				w.lastForcedExitAttempt.Store(signal.Symbol, time.Now())
-			}
-		case <-ctx.Done():
-			return
-		default:
-			// Increment dropped signal counter atomically
-			droppedCount := atomic.AddInt64(&w.droppedSignals, 1)
-			w.logger.Strategy().
-				WithField("dropped_count", droppedCount).
-				WithField("symbol", signal.Symbol).
-				WithField("action", signal.Action).
-				Warn("Signal channel is full, dropping signal")
+		if w.sendSignal(ctx, signal, isForcedExit) && isForcedExit {
+			w.lastForcedExitAttempt.Store(signal.Symbol, time.Now())
 		}
 	} else if signal.Action == strategy.SignalHold {
 		// Reset last sent signal when strategy returns to HOLD (trend reversed or insufficient data)

--- a/internal/adapter/worker/take_profit_test.go
+++ b/internal/adapter/worker/take_profit_test.go
@@ -10,8 +10,8 @@ import (
 func TestCheckTakeProfit_NoPositionReader(t *testing.T) {
 	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 2.0})
 	// No position reader set — must return nil
-	if got := w.checkTakeProfit("ETH_JPY", 340000.0); got != nil {
-		t.Fatalf("expected nil when no position reader, got %+v", got)
+	if got, err := w.checkTakeProfit("ETH_JPY", 340000.0); got != nil || err != nil {
+		t.Fatalf("expected nil when no position reader, got %+v (err=%v)", got, err)
 	}
 }
 
@@ -19,8 +19,8 @@ func TestCheckTakeProfit_NoOpenPositions(t *testing.T) {
 	w := newTestStrategyWorker(t, map[string]any{"take_profit_pct": 2.0})
 	w.SetPositionReader(&mockPositionReader{positions: []domain.Position{}})
 
-	if got := w.checkTakeProfit("ETH_JPY", 340000.0); got != nil {
-		t.Fatalf("expected nil for empty positions, got %+v", got)
+	if got, err := w.checkTakeProfit("ETH_JPY", 340000.0); got != nil || err != nil {
+		t.Fatalf("expected nil for empty positions, got %+v (err=%v)", got, err)
 	}
 }
 
@@ -33,8 +33,8 @@ func TestCheckTakeProfit_NotTriggered(t *testing.T) {
 	})
 
 	// 2% above 330000 = 336600; current price 335000 is below TP → no trigger
-	if got := w.checkTakeProfit("ETH_JPY", 335000.0); got != nil {
-		t.Fatalf("take profit should not trigger at 335000 (tp=336600), got %+v", got)
+	if got, err := w.checkTakeProfit("ETH_JPY", 335000.0); got != nil || err != nil {
+		t.Fatalf("take profit should not trigger at 335000 (tp=336600), got %+v (err=%v)", got, err)
 	}
 }
 
@@ -47,7 +47,10 @@ func TestCheckTakeProfit_Triggered(t *testing.T) {
 	})
 
 	// 2% above 330000 = 336600; current price 340000 is above TP → trigger
-	got := w.checkTakeProfit("ETH_JPY", 340000.0)
+	got, err := w.checkTakeProfit("ETH_JPY", 340000.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got == nil {
 		t.Fatal("expected SELL signal when take profit triggers, got nil")
 	}
@@ -71,7 +74,10 @@ func TestCheckTakeProfit_ExactlyAtTakePrice(t *testing.T) {
 	})
 
 	// exactly at take price (330000 * 1.02 = 336600) must trigger
-	got := w.checkTakeProfit("ETH_JPY", 336600.0)
+	got, err := w.checkTakeProfit("ETH_JPY", 336600.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got == nil {
 		t.Fatal("expected SELL signal at exact take price, got nil")
 	}
@@ -86,8 +92,8 @@ func TestCheckTakeProfit_ZeroTakeProfitPct(t *testing.T) {
 	})
 
 	// take_profit_pct=0 means disabled
-	if got := w.checkTakeProfit("ETH_JPY", 999999.0); got != nil {
-		t.Fatalf("take profit should be disabled when pct=0, got %+v", got)
+	if got, err := w.checkTakeProfit("ETH_JPY", 999999.0); got != nil || err != nil {
+		t.Fatalf("take profit should be disabled when pct=0, got %+v (err=%v)", got, err)
 	}
 }
 
@@ -100,7 +106,10 @@ func TestCheckTakeProfit_PartialPosition_Triggered(t *testing.T) {
 	})
 
 	// 2% above 330792 = 337407.84; current price 340362 is above TP → trigger
-	got := w.checkTakeProfit("ETH_JPY", 340362.0)
+	got, err := w.checkTakeProfit("ETH_JPY", 340362.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got == nil {
 		t.Fatal("expected SELL signal for PARTIAL position above take price, got nil")
 	}
@@ -122,7 +131,10 @@ func TestCheckTakeProfit_MultiplePositions_FirstTriggered(t *testing.T) {
 	})
 
 	// 340000 > 336600 (first) but < 341700 (second) → triggers on first position
-	got := w.checkTakeProfit("ETH_JPY", 340000.0)
+	got, err := w.checkTakeProfit("ETH_JPY", 340000.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got == nil {
 		t.Fatal("expected SELL signal, got nil")
 	}


### PR DESCRIPTION
## Summary

Stop-loss and take-profit signals could be silently discarded in two different ways. Both failure modes are invisible in the logs' happy path yet directly expose open positions to unbounded loss. This PR makes forced exits reliable and makes position-read failures loud.

## Problems

### 1. Forced-exit signals were dropped when the signal channel was full

`executeStrategy` and `dispatchForcedExitIfAny` sent every signal through a non-blocking `select` with a `default:` branch that incremented `droppedSignals` and logged a warning.

That is the correct behavior for an ordinary strategy signal: the next tick regenerates it, so dropping is a cheap way to shed load. It is the wrong behavior for a stop-loss or take-profit signal. A forced exit is the mechanism that bounds the loss on an open position, and it is precisely under load — fast market, burst of ticks, slow order execution — that the channel fills up and the exit is most needed.

### 2. Position-read failures were logged at Warn and treated as "no position"

`checkStopLoss` and `checkTakeProfit` returned `nil` when the position repository returned an error, which is indistinguishable from "there is no open position". Two consequences:

- The forced exit for a genuinely open position was skipped.
- `executeStrategy` continued on to evaluate the strategy and could open a **new** position while the state of existing ones was unknown.

A failed read means "unknown", not "safe".

## Changes

- `checkStopLoss` / `checkTakeProfit` now return `(*strategy.Signal, error)` and propagate repository errors instead of swallowing them.
- New `forcedExitSignal` evaluates stop-loss first, then take-profit, propagating errors from either.
- New `reportPositionReadFailure` increments a `positionReadFailures` counter and logs at **Error** level with a `failure_count` field, so the condition is alertable rather than buried among warnings.
- New `sendSignal(ctx, signal, isForcedExit)`:
  - Ordinary signals keep the existing non-blocking fast path and are still dropped with a warning when the channel is full.
  - Forced exits fall back to a **bounded** blocking wait (`ForcedExitSendTimeout = 5s`) and log at Error level if even that times out. The wait also aborts on context cancellation, so shutdown is not delayed.
- `executeStrategy` suppresses BUY signals when the position read fails, while still allowing SELL through — never blocking an exit, never opening a new position blind.

The timeout is bounded on purpose: an unbounded block would stall the whole worker if the consumer were wedged. Five seconds is long enough to ride out a transient burst and short enough not to become a liveness problem.

## Tests

New `forced_exit_test.go` covers the behavior that was previously impossible to observe:

- `TestSendSignal_ForcedExitWaitsForRoomInsteadOfDropping`
- `TestSendSignal_OrdinarySignalIsDroppedWhenChannelFull` (pins the unchanged semantics)
- `TestSendSignal_ForcedExitAbortsOnContextCancel`
- `TestForcedExitSignal_PositionReadErrorIsReported`
- `TestExecuteStrategy_SuppressesBuyWhenPositionReadFails`
- `TestExecuteStrategy_AllowsSellWhenPositionReadFails`

Existing stop-loss and take-profit tests were updated for the new two-value signature.

`go test -race ./...` passes and `golangci-lint run` reports no issues.

## Compatibility

No configuration or API changes. The only externally visible difference is log severity: position-read failures now appear at Error instead of Warn, which is the intended outcome.
